### PR TITLE
Harden security, modernize error handling, and add CI/DevOps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.23"
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Test
+        run: go test -race -count=1 ./...
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.23"
+
+      - uses: golangci/golangci-lint-action@v6
+        with:
+          version: latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,28 @@
+run:
+  timeout: 3m
+
+linters:
+  enable:
+    - errcheck
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+    - gosimple
+    - gocritic
+    - misspell
+    - gofmt
+
+linters-settings:
+  gocritic:
+    enabled-tags:
+      - diagnostic
+      - performance
+    disabled-checks:
+      - appendAssign
+
+issues:
+  exclude-dirs:
+    - vendor
+  max-issues-per-linter: 50
+  max-same-issues: 5

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,15 @@
-FROM golang:1.22.0
+FROM golang:1.23.0 AS builder
 
 WORKDIR /go/src/github.com/Cuebiq/sarama-easy
 
-ADD . .
+COPY go.mod go.sum ./
+RUN go mod download
 
-ENV GO111MODULE=on
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /go/bin/ ./...
 
-RUN mkdir -p bin && go build -o bin/ ./...
+FROM gcr.io/distroless/static-debian12
 
-CMD ["echo use docker-compose up to run the examples"]
+COPY --from=builder /go/bin/ /usr/local/bin/
+
+CMD ["echo", "use docker-compose up to run the examples"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+.PHONY: test lint vet build docker clean
+
+test:
+	go test -race -count=1 -v ./...
+
+lint:
+	golangci-lint run ./...
+
+vet:
+	go vet ./...
+
+build:
+	go build -o bin/ ./...
+
+docker:
+	docker build -t sarama-easy .
+
+clean:
+	rm -rf bin/

--- a/README.md
+++ b/README.md
@@ -1,22 +1,200 @@
 # sarama-easy
 
-[Sarama](https://github.com/IBM/sarama) is a Golang client for Apache Kafka. This is a light wrapper and example demo for Sarama's async producer and consumer (including auto-rebalancing consumer groups.)
+A lightweight Go wrapper around [IBM/sarama](https://github.com/IBM/sarama) for Apache Kafka. Provides simplified APIs for async producers and consumers (including auto-rebalancing consumer groups) with built-in Avro serialization via Confluent Schema Registry.
 
-## Usage
+## Features
 
-#### Run the demo producer/consumer
+- **Async Producer** with context-based graceful shutdown
+- **Consumer Groups** with auto-rebalancing and configurable strategies
+- **Avro Support** using Confluent wire format and Schema Registry
+- **Schema Registry Client** with thread-safe caching
+- **TLS/mTLS** and **SASL SCRAM** (SHA-256/SHA-512) authentication
+- **Environment-based configuration** via `envconfig`
+
+## Installation
+
 ```bash
-# From the root dir of the repo checkout:
-script/build
-
-docker-compose up
-
-# From another terminal session:
-bin/consumer-example &
-
-bin/producer-example
+go get github.com/Cuebiq/sarama-easy
 ```
 
-#### Result
-* Producer will emit 10 messages and a sentinel value to the example topic, then shut down.
-* Consumer will receive 10 example messages, and a sentinel message triggering it's own shutdown.
+## Quick Start
+
+### Producer
+
+```go
+ctx, cancel := context.WithCancel(context.Background())
+defer cancel()
+
+conf := kafka.NewKafkaConfig()
+conf.Brokers = "localhost:9092"
+
+logger := log.New(os.Stdout, "[producer] ", log.LstdFlags)
+
+producer, err := kafka.NewProducer(ctx, conf, logger)
+if err != nil {
+    log.Fatal(err)
+}
+
+// Start the background process and error consumer
+processor, errors := producer.Background()
+go processor()
+go func() {
+    for err := range errors {
+        log.Printf("error: %s", err)
+    }
+}()
+
+// Send messages
+producer.Send(kafka.ProducerMessage{
+    Topic: "my-topic",
+    Key:   []byte("key"),
+    Value: []byte("value"),
+})
+
+// Trigger graceful shutdown
+cancel()
+```
+
+### Consumer
+
+```go
+ctx, cancel := context.WithCancel(context.Background())
+
+handler := &myHandler{cancel: cancel}
+
+consumer, err := kafka.NewConsumer(ctx, conf, handler, logger)
+if err != nil {
+    log.Fatal(err)
+}
+
+processor, errors := consumer.Background()
+go processor()
+
+for err := range errors {
+    log.Printf("error: %s", err)
+}
+```
+
+### Handler
+
+Implement the `Handler` interface to process incoming messages:
+
+```go
+type myHandler struct {
+    cancel context.CancelFunc
+}
+
+func (h *myHandler) Handle(msg *kafka.Message) error {
+    fmt.Printf("topic=%s key=%s value=%s\n", msg.Topic, msg.Key, msg.Value)
+    return nil // return error to trigger consumer shutdown
+}
+```
+
+## Configuration
+
+All configuration fields can be set via environment variables, code, or CLI flags.
+
+| Field | Env Variable | Default | Description |
+|-------|-------------|---------|-------------|
+| `Brokers` | `KAFKA_BROKERS` | `localhost:9092` | CSV list of Kafka broker addresses |
+| `Version` | `KAFKA_VERSION` | `1.1.0` | Kafka broker version for API compatibility |
+| `ClientID` | `KAFKA_CLIENT_ID` | `sarama-easy` | Client identifier sent to brokers |
+| `Topics` | `KAFKA_TOPICS` | | CSV list of topics to consume |
+| `Group` | `KAFKA_GROUP` | `default-group` | Consumer group ID |
+| `RebalanceStrategy` | `KAFKA_REBALANCE_STRATEGY` | `roundrobin` | `roundrobin` or `range` |
+| `RebalanceTimeout` | `KAFKA_REBALANCE_TIMEOUT` | `1m` | Consumer rebalance timeout |
+| `InitOffsets` | `KAFKA_INIT_OFFSETS` | `latest` | `latest` or `earliest` |
+| `CommitInterval` | `KAFKA_COMMIT_INTERVAL` | `10s` | Auto-commit interval |
+| `FlushInterval` | `KAFKA_FLUSH_INTERVAL` | `1s` | Producer flush interval |
+| `IsolationLevel` | `KAFKA_ISOLATION_LEVEL` | `ReadUncommitted` | `ReadUncommitted` or `ReadCommitted` |
+| `Verbose` | `KAFKA_VERBOSE` | `false` | Enable Sarama internal logging |
+
+### TLS
+
+| Field | Env Variable | Description |
+|-------|-------------|-------------|
+| `TLSEnabled` | `KAFKA_TLS_ENABLED` | Enable TLS |
+| `TLSKey` | `KAFKA_TLS_KEY` | Path to client private key |
+| `TLSCert` | `KAFKA_TLS_CERT` | Path to client certificate |
+| `CACerts` | `KAFKA_CA_CERTS` | Path to CA certificate bundle |
+
+### SASL
+
+| Field | Env Variable | Description |
+|-------|-------------|-------------|
+| `SaslEnabled` | `KAFKA_SASL_ENABLED` | Enable SASL authentication |
+| `SaslMechanism` | `KAFKA_SASL_MECHANISM` | `SCRAM-SHA-256` or `SCRAM-SHA-512` |
+| `Username` | `KAFKA_USERNAME` | SASL username |
+| `Password` | `KAFKA_PASSWORD` | SASL password |
+
+### Schema Registry
+
+| Field | Env Variable | Description |
+|-------|-------------|-------------|
+| `SchemaRegistryServers` | `KAFKA_SCHEMA_REGISTRY_SERVERS` | CSV list of Schema Registry URLs |
+
+## Avro Support
+
+### Producing Avro Messages
+
+```go
+codec, err := goavro.NewCodec(avroSchema)
+schemaID, err := producer.GetSchemaId("my-topic", codec)
+
+native, err := codec.BinaryFromNative(nil, record)
+msg := &sarama.ProducerMessage{
+    Topic: "my-topic",
+    Key:   sarama.StringEncoder("key"),
+    Value: &kafka.AvroEncoder{SchemaID: schemaID, Content: native},
+}
+producer.SendAvroMsg(msg)
+```
+
+### Consuming Avro Messages
+
+Avro decoding is handled automatically by the consumer. The `Message.Value` field contains the JSON-encoded Avro data, and `Message.SchemaId` holds the schema ID from the registry.
+
+## Running the Examples
+
+```bash
+# Start Kafka and Schema Registry
+docker compose up -d
+
+# Wait for services to be healthy, then:
+go build -o bin/ ./...
+
+# In one terminal:
+bin/consumer-example -brokers localhost:9092 -topic mytopic -version 3.5.0
+
+# In another terminal:
+bin/producer-example -brokers localhost:9092 -topic mytopic -version 3.5.0
+
+# Clean up
+docker compose down -v
+```
+
+The producer sends 10 messages and a sentinel ("poison pill"). The consumer receives all messages and shuts down when it sees the sentinel.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────┐
+│                  Application                 │
+│                                              │
+│  ┌──────────┐  Handler   ┌──────────────┐   │
+│  │ Consumer ├───────────►│ Your Handler │   │
+│  └────┬─────┘            └──────────────┘   │
+│       │                                      │
+│  ┌────┴─────┐  Send()   ┌──────────────┐   │
+│  │ Producer ├───────────►│ Kafka Broker │   │
+│  └────┬─────┘            └──────────────┘   │
+│       │                                      │
+│  ┌────┴─────────────────┐                   │
+│  │ CachedSchemaRegistry │◄──► Schema Reg.   │
+│  └──────────────────────┘                   │
+└─────────────────────────────────────────────┘
+```
+
+## License
+
+Apache License 2.0 - see [LICENSE](LICENSE) for details.

--- a/cmd/consumer-example/main.go
+++ b/cmd/consumer-example/main.go
@@ -57,12 +57,10 @@ func init() {
 	flag.Parse()
 
 	// Log the final configuration for verification
-	log.Printf("Config: %+v\n", conf)
+	log.Printf("Config: %s\n", conf)
 }
 
 func main() {
-	flag.Parse()
-
 	logger := log.New(os.Stdout, "[example Kafka consumer] ", log.LstdFlags|log.LUTC|log.Lshortfile)
 
 	// context can be canceled, initiating kafka.Consumer shutdown, from

--- a/cmd/consumer-example/main.go
+++ b/cmd/consumer-example/main.go
@@ -74,7 +74,7 @@ func main() {
 		logger:     logger,
 	}
 
-	consumer, err := kafka.NewConsumer(ctx, conf, handlers, logger)
+	consumer, err := kafka.NewConsumer(ctx, &conf, handlers, logger)
 	if err != nil {
 		logger.Fatal(err)
 	}

--- a/cmd/producer-example/main.go
+++ b/cmd/producer-example/main.go
@@ -108,7 +108,7 @@ func main() {
 		logger.Printf("Sending message %d", i+1)
 
 		if err := producer.Send(msg); err != nil {
-			logger.Printf(err.Error()) // only happens if context is cancelled while Send() is blocked on full queue
+			logger.Print(err.Error()) // only happens if context is cancelled while Send() is blocked on full queue
 			break
 		}
 	}
@@ -119,7 +119,7 @@ func main() {
 		Key:   []byte("poison pill"),
 		Value: []byte{},
 	}
-	producer.Send(pill)
+	_ = producer.Send(pill)
 
 	// signal the producer's background client to gracefully shut down
 	cancelable()

--- a/cmd/producer-example/main.go
+++ b/cmd/producer-example/main.go
@@ -57,18 +57,17 @@ func init() {
 	flag.StringVar(&conf.SaslMechanism, "saslmechanism", conf.SaslMechanism, "SASL Mechanism")
 	flag.BoolVar(&conf.SaslEnabled, "saslEnabled", conf.SaslEnabled, "SASL enabled")
 
+	flag.StringVar(&topic, "topic", "mytopic", "Kafka topic to produce messages to")
 	flag.IntVar(&count, "count", 10, "Number of example messages to produce")
 
 	// Parse the command-line flags
 	flag.Parse()
 
 	// Log the final configuration for verification
-	log.Printf("Config: %+v\n", conf)
+	log.Printf("Config: %s\n", conf)
 }
 
 func main() {
-	flag.Parse()
-
 	logger := log.New(os.Stdout, "[example Kafka producer] ", log.LstdFlags|log.LUTC|log.Lshortfile)
 
 	ctx, cancelable := context.WithCancel(context.Background())

--- a/cmd/producer-example/main.go
+++ b/cmd/producer-example/main.go
@@ -72,7 +72,7 @@ func main() {
 
 	ctx, cancelable := context.WithCancel(context.Background())
 
-	producer, err := kafka.NewProducer(ctx, conf, logger)
+	producer, err := kafka.NewProducer(ctx, &conf, logger)
 	if err != nil {
 		logger.Fatal(err)
 	}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,21 +1,27 @@
-version: '3.4'
-
 services:
   zoo1:
-    image: confluentinc/cp-zookeeper:6.2.1
+    image: confluentinc/cp-zookeeper:7.5.0
     hostname: zoo1
     container_name: zoo1
+    platform: linux/amd64
     ports:
       - "2181:2181"
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_SERVER_ID: 1
       ZOOKEEPER_SERVERS: zoo1:2888:3888
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8080/commands/ruok || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
 
   kafka1:
-    image: confluentinc/cp-kafka:6.2.1
+    image: confluentinc/cp-kafka:7.5.0
     hostname: kafka1
-    user: "appuser:appuser"
+    container_name: kafka1
+    platform: linux/amd64
     ports:
       - "9092:9092"
       - "9999:9999"
@@ -32,17 +38,32 @@ services:
       KAFKA_JMX_PORT: 9999
       KAFKA_JMX_HOSTNAME: ${DOCKER_HOST_IP:-127.0.0.1}
     depends_on:
-      - zoo1
+      zoo1:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "kafka-broker-api-versions --bootstrap-server localhost:9092"]
+      interval: 10s
+      timeout: 10s
+      retries: 10
+      start_period: 30s
 
   kafka-schema-registry:
-    image: confluentinc/cp-schema-registry:6.2.1
+    image: confluentinc/cp-schema-registry:7.5.0
     hostname: kafka-schema-registry
+    container_name: kafka-schema-registry
+    platform: linux/amd64
     depends_on:
-      - zoo1
-      - kafka1
+      kafka1:
+        condition: service_healthy
     ports:
       - "8081:8081"
     environment:
       SCHEMA_REGISTRY_HOST_NAME: kafka-schema-registry
-      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: 'PLAINTEXT://kafka1:19092,PLAINTEXT://kafka2:19093,PLAINTEXT://kafka3:19094'
+      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: 'PLAINTEXT://kafka1:19092'
       SCHEMA_REGISTRY_LISTENERS: http://0.0.0.0:8081
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8081/ || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/IBM/sarama v1.46.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/linkedin/goavro/v2 v2.10.1
-	github.com/pkg/errors v0.8.1
 	github.com/xdg/scram v1.0.5
 )
 

--- a/go.sum
+++ b/go.sum
@@ -39,8 +39,6 @@ github.com/linkedin/goavro/v2 v2.10.1 h1:ExVurHDnf0eyUocILs48kiZ4pGvaEbDvBOQcfLr
 github.com/linkedin/goavro/v2 v2.10.1/go.mod h1:UgQUb2N/pmueQYH9bfqFioWxzYCZXSfF8Jw03O5sjqA=
 github.com/pierrec/lz4/v4 v4.1.22 h1:cKFw6uJDK+/gfw5BcDL0JL5aBsAFdsIT18eRtLj7VIU=
 github.com/pierrec/lz4/v4 v4.1.22/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
-github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
-github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rcrowley/go-metrics v0.0.0-20250401214520-65e299d6c5c9 h1:bsUq1dX0N8AOIL7EB/X911+m4EHsnWEHeJ0c+3TTBrg=

--- a/kafka/cachedSchemaRegistry.go
+++ b/kafka/cachedSchemaRegistry.go
@@ -1,97 +1,148 @@
 package kafka
 
 import (
-	"github.com/linkedin/goavro/v2"
 	"sync"
+	"time"
+
+	"github.com/linkedin/goavro/v2"
 )
 
-// CachedSchemaRegistryClient is a schema registry client that will cache some data to improve performance
+type schemaCacheEntry struct {
+	codec     *goavro.Codec
+	fetchedAt time.Time
+}
+
+type idCacheEntry struct {
+	id        int
+	fetchedAt time.Time
+}
+
+// CachedSchemaRegistryClient wraps SchemaRegistryClient with thread-safe caching
+// for schema lookups (by ID) and schema registrations (by JSON). This avoids
+// redundant HTTP calls when the same schema is requested multiple times.
+// When cacheTTL is set, entries expire after the given duration and are re-fetched.
 type CachedSchemaRegistryClient struct {
-	SchemaRegistryClient *SchemaRegistryClient
-	schemaCache          map[int]*goavro.Codec
+	schemaRegistryClient *SchemaRegistryClient
+	schemaCache          map[int]*schemaCacheEntry
 	schemaCacheLock      sync.RWMutex
-	schemaIdCache        map[string]int
+	schemaIdCache        map[string]*idCacheEntry
 	schemaIdCacheLock    sync.RWMutex
+	cacheTTL             time.Duration
 }
 
 func NewCachedSchemaRegistryClient(connect []string) *CachedSchemaRegistryClient {
-	SchemaRegistryClient := NewSchemaRegistryClient(connect)
-	return &CachedSchemaRegistryClient{SchemaRegistryClient: SchemaRegistryClient, schemaCache: make(map[int]*goavro.Codec), schemaIdCache: make(map[string]int)}
+	return NewCachedSchemaRegistryClientWithOptions(connect, len(connect), 0, 0)
 }
 
 func NewCachedSchemaRegistryClientWithRetries(connect []string, retries int) *CachedSchemaRegistryClient {
-	SchemaRegistryClient := NewSchemaRegistryClientWithRetries(connect, retries)
-	return &CachedSchemaRegistryClient{SchemaRegistryClient: SchemaRegistryClient, schemaCache: make(map[int]*goavro.Codec), schemaIdCache: make(map[string]int)}
+	return NewCachedSchemaRegistryClientWithOptions(connect, retries, 0, 0)
 }
 
-// GetSchema will return and cache the codec with the given id
-func (client *CachedSchemaRegistryClient) GetSchema(id int) (*goavro.Codec, error) {
-	client.schemaCacheLock.RLock()
-	cachedResult := client.schemaCache[id]
-	client.schemaCacheLock.RUnlock()
-	if nil != cachedResult {
-		return cachedResult, nil
+// NewCachedSchemaRegistryClientWithOptions creates a cached client with configurable retries,
+// HTTP timeout, and cache TTL. Zero values use defaults (2s timeout, no TTL expiration).
+func NewCachedSchemaRegistryClientWithOptions(connect []string, retries int, timeout time.Duration, cacheTTL time.Duration) *CachedSchemaRegistryClient {
+	srClient := NewSchemaRegistryClientWithOptions(connect, retries, timeout)
+	return &CachedSchemaRegistryClient{
+		schemaRegistryClient: srClient,
+		schemaCache:          make(map[int]*schemaCacheEntry),
+		schemaIdCache:        make(map[string]*idCacheEntry),
+		cacheTTL:             cacheTTL,
 	}
-	codec, err := client.SchemaRegistryClient.GetSchema(id)
+}
+
+func (client *CachedSchemaRegistryClient) isExpired(fetchedAt time.Time) bool {
+	return client.cacheTTL > 0 && time.Since(fetchedAt) > client.cacheTTL
+}
+
+// GetSchema will return and cache the codec with the given id.
+// Uses double-check locking to prevent duplicate fetches under contention.
+func (client *CachedSchemaRegistryClient) GetSchema(id int) (*goavro.Codec, error) {
+	// Fast path: read lock only
+	client.schemaCacheLock.RLock()
+	entry := client.schemaCache[id]
+	client.schemaCacheLock.RUnlock()
+	if entry != nil && !client.isExpired(entry.fetchedAt) {
+		return entry.codec, nil
+	}
+
+	// Slow path: acquire write lock and double-check before fetching
+	client.schemaCacheLock.Lock()
+	defer client.schemaCacheLock.Unlock()
+
+	// Another goroutine may have populated the cache while we waited for the lock
+	if entry = client.schemaCache[id]; entry != nil && !client.isExpired(entry.fetchedAt) {
+		return entry.codec, nil
+	}
+
+	codec, err := client.schemaRegistryClient.GetSchema(id)
 	if err != nil {
 		return nil, err
 	}
-	client.schemaCacheLock.Lock()
-	client.schemaCache[id] = codec
-	client.schemaCacheLock.Unlock()
+	client.schemaCache[id] = &schemaCacheEntry{codec: codec, fetchedAt: time.Now()}
 	return codec, nil
 }
 
 // GetSubjects returns a list of subjects
 func (client *CachedSchemaRegistryClient) GetSubjects() ([]string, error) {
-	return client.SchemaRegistryClient.GetSubjects()
+	return client.schemaRegistryClient.GetSubjects()
 }
 
 // GetVersions returns a list of all versions of a subject
 func (client *CachedSchemaRegistryClient) GetVersions(subject string) ([]int, error) {
-	return client.SchemaRegistryClient.GetVersions(subject)
+	return client.schemaRegistryClient.GetVersions(subject)
 }
 
 // GetSchemaByVersion returns the codec for a specific version of a subject
 func (client *CachedSchemaRegistryClient) GetSchemaByVersion(subject string, version int) (*goavro.Codec, error) {
-	return client.SchemaRegistryClient.GetSchemaByVersion(subject, version)
+	return client.schemaRegistryClient.GetSchemaByVersion(subject, version)
 }
 
 // GetLatestSchema returns the highest version schema for a subject
 func (client *CachedSchemaRegistryClient) GetLatestSchema(subject string) (*goavro.Codec, error) {
-	return client.SchemaRegistryClient.GetLatestSchema(subject)
+	return client.schemaRegistryClient.GetLatestSchema(subject)
 }
 
-// CreateSubject will return and cache the id with the given codec
+// CreateSubject will return and cache the id with the given codec.
+// Uses double-check locking to prevent duplicate registrations under contention.
 func (client *CachedSchemaRegistryClient) CreateSubject(subject string, codec *goavro.Codec) (int, error) {
 	schemaJson := codec.Schema()
+
+	// Fast path: read lock only
 	client.schemaIdCacheLock.RLock()
-	cachedResult, found := client.schemaIdCache[schemaJson]
+	entry := client.schemaIdCache[schemaJson]
 	client.schemaIdCacheLock.RUnlock()
-	if found {
-		return cachedResult, nil
+	if entry != nil && !client.isExpired(entry.fetchedAt) {
+		return entry.id, nil
 	}
-	id, err := client.SchemaRegistryClient.CreateSubject(subject, codec)
+
+	// Slow path: acquire write lock and double-check before registering
+	client.schemaIdCacheLock.Lock()
+	defer client.schemaIdCacheLock.Unlock()
+
+	// Another goroutine may have registered while we waited for the lock
+	if entry = client.schemaIdCache[schemaJson]; entry != nil && !client.isExpired(entry.fetchedAt) {
+		return entry.id, nil
+	}
+
+	id, err := client.schemaRegistryClient.CreateSubject(subject, codec)
 	if err != nil {
 		return 0, err
 	}
-	client.schemaIdCacheLock.Lock()
-	client.schemaIdCache[schemaJson] = id
-	client.schemaIdCacheLock.Unlock()
+	client.schemaIdCache[schemaJson] = &idCacheEntry{id: id, fetchedAt: time.Now()}
 	return id, nil
 }
 
 // IsSchemaRegistered checks if a specific codec is already registered to a subject
 func (client *CachedSchemaRegistryClient) IsSchemaRegistered(subject string, codec *goavro.Codec) (int, error) {
-	return client.SchemaRegistryClient.IsSchemaRegistered(subject, codec)
+	return client.schemaRegistryClient.IsSchemaRegistered(subject, codec)
 }
 
 // DeleteSubject deletes the subject, should only be used in development
 func (client *CachedSchemaRegistryClient) DeleteSubject(subject string) error {
-	return client.SchemaRegistryClient.DeleteSubject(subject)
+	return client.schemaRegistryClient.DeleteSubject(subject)
 }
 
 // DeleteVersion deletes the a specific version of a subject, should only be used in development.
 func (client *CachedSchemaRegistryClient) DeleteVersion(subject string, version int) error {
-	return client.SchemaRegistryClient.DeleteVersion(subject, version)
+	return client.schemaRegistryClient.DeleteVersion(subject, version)
 }

--- a/kafka/config.go
+++ b/kafka/config.go
@@ -1,21 +1,24 @@
 package kafka
 
 import (
-	"crypto/tls"
-	"crypto/x509"
-	"io/ioutil"
-	"time"
-
 	"crypto/sha256"
 	"crypto/sha512"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
 	"github.com/IBM/sarama"
 	from_env "github.com/kelseyhightower/envconfig"
-	"github.com/pkg/errors"
 	"github.com/xdg/scram"
 )
 
-// simple Kafka config abstraction; can be populated from env vars
-// via FromEnv() or fields can applied to CLI flags by the caller.
+// Config holds the Kafka client configuration. Fields can be populated from
+// environment variables via FromEnv(), from defaults via NewKafkaConfig(),
+// or bound to CLI flags by the caller. Each field is tagged with the
+// corresponding environment variable name.
 type Config struct {
 	Username string `envconfig:"KAFKA_USERNAME"`
 	Password string `envconfig:"KAFKA_PASSWORD"`
@@ -42,12 +45,25 @@ type Config struct {
 	FlushInterval time.Duration `envconfig:"KAFKA_FLUSH_INTERVAL"`
 
 	// Schema Registry server
-	SchemaRegistryServers string `envconfig:"KAFKA_SCHEMA_REGISTRY_SERVERS"`
+	SchemaRegistryServers string        `envconfig:"KAFKA_SCHEMA_REGISTRY_SERVERS"`
+	SchemaRegistryTimeout time.Duration `envconfig:"KAFKA_SCHEMA_REGISTRY_TIMEOUT"`
 
 	IsolationLevel string `envconfig:"KAFKA_ISOLATION_LEVEL"`
 
 	SaslMechanism string `envconfig:"KAFKA_SASL_MECHANISM"`
 	SaslEnabled   bool   `envconfig:"KAFKA_SASL_ENABLED"`
+}
+
+// String returns a string representation of the Config with sensitive fields masked
+func (c Config) String() string {
+	password := "****"
+	if c.Password == "" {
+		password = ""
+	}
+	return fmt.Sprintf("{Brokers:%s Version:%s Verbose:%t ClientID:%s Topics:%s TLSEnabled:%t Group:%s RebalanceStrategy:%s InitOffsets:%s Username:%s Password:%s SaslEnabled:%t SaslMechanism:%s}",
+		c.Brokers, c.Version, c.Verbose, c.ClientID, c.Topics, c.TLSEnabled,
+		c.Group, c.RebalanceStrategy, c.InitOffsets, c.Username, password,
+		c.SaslEnabled, c.SaslMechanism)
 }
 
 // returns a new kafka.Config with reasonable defaults for some values
@@ -73,6 +89,9 @@ func FromEnv() (Config, error) {
 	return conf, err
 }
 
+// errorQueueSize is the buffer size for the async error channel shared between
+// the Sarama client and the caller. A buffer of 32 prevents blocking the
+// internal Sarama goroutines when errors arrive in bursts.
 const errorQueueSize = 32
 
 // apply env config properties to a Sarama consumer config
@@ -81,10 +100,10 @@ func configureConsumer(envConf Config) (*sarama.Config, error) {
 	saramaConf.Net.TLS.Enable = envConf.TLSEnabled
 	configureSasl(envConf, saramaConf)
 
-	// Kafka broker version is mandatory for API compatability
+	// Kafka broker version is mandatory for API compatibility
 	version, err := sarama.ParseKafkaVersion(envConf.Version)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error parsing Kafka version: %v", envConf.Version)
+		return nil, fmt.Errorf("error parsing Kafka version %q: %w", envConf.Version, err)
 	}
 	saramaConf.Version = version
 
@@ -106,7 +125,7 @@ func configureConsumer(envConf Config) (*sarama.Config, error) {
 	case "range":
 		saramaConf.Consumer.Group.Rebalance.Strategy = sarama.BalanceStrategyRange
 	default:
-		return nil, errors.Errorf("unrecognized consumer group partition strategy: %s", envConf.RebalanceStrategy)
+		return nil, fmt.Errorf("unrecognized consumer group partition strategy: %s", envConf.RebalanceStrategy)
 	}
 	// configure group rebalance strategy
 	switch envConf.IsolationLevel {
@@ -125,7 +144,7 @@ func configureConsumer(envConf Config) (*sarama.Config, error) {
 	case "latest":
 		saramaConf.Consumer.Offsets.Initial = sarama.OffsetNewest
 	default:
-		return nil, errors.Errorf("failed to parse Kafka initial offset from service saramaConf: %s", envConf.InitOffsets)
+		return nil, fmt.Errorf("failed to parse Kafka initial offset from service config: %s", envConf.InitOffsets)
 	}
 
 	return saramaConf, nil
@@ -137,7 +156,6 @@ func configureSasl(envConf Config, saramaConf *sarama.Config) {
 		saramaConf.Net.SASL.Mechanism = sarama.SASLMechanism(envConf.SaslMechanism)
 		saramaConf.Net.SASL.User = envConf.Username
 		saramaConf.Net.SASL.Password = envConf.Password
-		saramaConf.Net.SASL.Enable = envConf.SaslEnabled
 		if envConf.SaslMechanism == sarama.SASLTypeSCRAMSHA256 {
 			saramaConf.Net.SASL.SCRAMClientGeneratorFunc = func() sarama.SCRAMClient {
 				return &XDGSCRAMClient{HashGeneratorFcn: SHA256}
@@ -193,7 +211,7 @@ func configureProducer(envConf Config) (*sarama.Config, error) {
 
 	version, err := sarama.ParseKafkaVersion(envConf.Version)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error parsing Kafka version: %v", envConf.Version)
+		return nil, fmt.Errorf("error parsing Kafka version %q: %w", envConf.Version, err)
 	}
 
 	if err := configureTLS(envConf, saramaConf); err != nil {
@@ -214,28 +232,35 @@ func configureProducer(envConf Config) (*sarama.Config, error) {
 
 // side effect TLS setup into Sarama config if env config specifies to do so
 func configureTLS(envConf Config, saramaConf *sarama.Config) error {
-	// configure TLS
-	if envConf.CACerts != "" {
-		cert, err := tls.LoadX509KeyPair(envConf.TLSCert, envConf.TLSKey)
-		if err != nil {
-			return errors.Wrapf(err, "failed to load TLS cert(%s) and key(%s)", envConf.TLSCert, envConf.TLSKey)
-		}
-
-		ca, err := ioutil.ReadFile(envConf.CACerts)
-		if err != nil {
-			return errors.Wrapf(err, "failed to load CA cert bundle at: %s", envConf.CACerts)
-		}
-
-		pool := x509.NewCertPool()
-		pool.AppendCertsFromPEM(ca)
-
-		tlsCfg := &tls.Config{
-			Certificates: []tls.Certificate{cert},
-			RootCAs:      pool,
-		}
-
-		saramaConf.Net.TLS.Config = tlsCfg
+	if !envConf.TLSEnabled {
+		return nil
 	}
 
+	if envConf.CACerts == "" || envConf.TLSCert == "" || envConf.TLSKey == "" {
+		return errors.New("TLS enabled but CACerts, TLSCert, and TLSKey are all required")
+	}
+
+	cert, err := tls.LoadX509KeyPair(envConf.TLSCert, envConf.TLSKey)
+	if err != nil {
+		return fmt.Errorf("failed to load TLS cert(%s) and key(%s): %w", envConf.TLSCert, envConf.TLSKey, err)
+	}
+
+	ca, err := os.ReadFile(envConf.CACerts)
+	if err != nil {
+		return fmt.Errorf("failed to load CA cert bundle at %s: %w", envConf.CACerts, err)
+	}
+
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(ca) {
+		return fmt.Errorf("CA cert bundle at %s contains no valid PEM certificates", envConf.CACerts)
+	}
+
+	tlsCfg := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		RootCAs:      pool,
+		MinVersion:   tls.VersionTLS12,
+	}
+
+	saramaConf.Net.TLS.Config = tlsCfg
 	return nil
 }

--- a/kafka/config.go
+++ b/kafka/config.go
@@ -95,7 +95,7 @@ func FromEnv() (Config, error) {
 const errorQueueSize = 32
 
 // apply env config properties to a Sarama consumer config
-func configureConsumer(envConf Config) (*sarama.Config, error) {
+func configureConsumer(envConf *Config) (*sarama.Config, error) {
 	saramaConf := sarama.NewConfig()
 	saramaConf.Net.TLS.Enable = envConf.TLSEnabled
 	configureSasl(envConf, saramaConf)
@@ -121,9 +121,9 @@ func configureConsumer(envConf Config) (*sarama.Config, error) {
 	// configure group rebalance strategy
 	switch envConf.RebalanceStrategy {
 	case "roundrobin":
-		saramaConf.Consumer.Group.Rebalance.Strategy = sarama.BalanceStrategyRoundRobin
+		saramaConf.Consumer.Group.Rebalance.Strategy = sarama.NewBalanceStrategyRoundRobin()
 	case "range":
-		saramaConf.Consumer.Group.Rebalance.Strategy = sarama.BalanceStrategyRange
+		saramaConf.Consumer.Group.Rebalance.Strategy = sarama.NewBalanceStrategyRange()
 	default:
 		return nil, fmt.Errorf("unrecognized consumer group partition strategy: %s", envConf.RebalanceStrategy)
 	}
@@ -150,7 +150,7 @@ func configureConsumer(envConf Config) (*sarama.Config, error) {
 	return saramaConf, nil
 }
 
-func configureSasl(envConf Config, saramaConf *sarama.Config) {
+func configureSasl(envConf *Config, saramaConf *sarama.Config) {
 	if envConf.SaslEnabled {
 		saramaConf.Net.SASL.Enable = envConf.SaslEnabled
 		saramaConf.Net.SASL.Mechanism = sarama.SASLMechanism(envConf.SaslMechanism)
@@ -204,7 +204,7 @@ func (x *XDGSCRAMClient) Done() bool {
 }
 
 // apply env config properties into a Sarama producer config
-func configureProducer(envConf Config) (*sarama.Config, error) {
+func configureProducer(envConf *Config) (*sarama.Config, error) {
 	saramaConf := sarama.NewConfig()
 	saramaConf.Net.TLS.Enable = envConf.TLSEnabled
 	configureSasl(envConf, saramaConf)
@@ -218,7 +218,7 @@ func configureProducer(envConf Config) (*sarama.Config, error) {
 		return nil, err
 	}
 
-	// Produce side configs (TODO: tune and customize more settings if needed)
+	// Producer side configs (TODO: tune and customize more settings if needed)
 	saramaConf.Version = version
 	saramaConf.ClientID = envConf.ClientID
 	saramaConf.Producer.RequiredAcks = sarama.WaitForLocal     // Only wait for the leader to ack
@@ -231,7 +231,7 @@ func configureProducer(envConf Config) (*sarama.Config, error) {
 }
 
 // side effect TLS setup into Sarama config if env config specifies to do so
-func configureTLS(envConf Config, saramaConf *sarama.Config) error {
+func configureTLS(envConf *Config, saramaConf *sarama.Config) error {
 	if !envConf.TLSEnabled {
 		return nil
 	}

--- a/kafka/config_test.go
+++ b/kafka/config_test.go
@@ -73,7 +73,7 @@ func TestConfigureConsumer_ValidConfig(t *testing.T) {
 	conf := NewKafkaConfig()
 	conf.Topics = "test-topic"
 
-	saramaConf, err := configureConsumer(conf)
+	saramaConf, err := configureConsumer(&conf)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -92,7 +92,7 @@ func TestConfigureConsumer_InvalidVersion(t *testing.T) {
 	conf := NewKafkaConfig()
 	conf.Version = "invalid"
 
-	_, err := configureConsumer(conf)
+	_, err := configureConsumer(&conf)
 	if err == nil {
 		t.Fatal("expected error for invalid Kafka version")
 	}
@@ -102,7 +102,7 @@ func TestConfigureConsumer_InvalidRebalanceStrategy(t *testing.T) {
 	conf := NewKafkaConfig()
 	conf.RebalanceStrategy = "unknown"
 
-	_, err := configureConsumer(conf)
+	_, err := configureConsumer(&conf)
 	if err == nil {
 		t.Fatal("expected error for invalid rebalance strategy")
 	}
@@ -112,7 +112,7 @@ func TestConfigureConsumer_InvalidInitOffsets(t *testing.T) {
 	conf := NewKafkaConfig()
 	conf.InitOffsets = "invalid"
 
-	_, err := configureConsumer(conf)
+	_, err := configureConsumer(&conf)
 	if err == nil {
 		t.Fatal("expected error for invalid init offsets")
 	}
@@ -122,7 +122,7 @@ func TestConfigureConsumer_RangeStrategy(t *testing.T) {
 	conf := NewKafkaConfig()
 	conf.RebalanceStrategy = "range"
 
-	saramaConf, err := configureConsumer(conf)
+	saramaConf, err := configureConsumer(&conf)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -147,7 +147,7 @@ func TestConfigureConsumer_IsolationLevels(t *testing.T) {
 			conf := NewKafkaConfig()
 			conf.IsolationLevel = tt.level
 
-			saramaConf, err := configureConsumer(conf)
+			saramaConf, err := configureConsumer(&conf)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -162,7 +162,7 @@ func TestConfigureConsumer_EarliestOffsets(t *testing.T) {
 	conf := NewKafkaConfig()
 	conf.InitOffsets = "earliest"
 
-	saramaConf, err := configureConsumer(conf)
+	saramaConf, err := configureConsumer(&conf)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -174,7 +174,7 @@ func TestConfigureConsumer_EarliestOffsets(t *testing.T) {
 func TestConfigureProducer_ValidConfig(t *testing.T) {
 	conf := NewKafkaConfig()
 
-	saramaConf, err := configureProducer(conf)
+	saramaConf, err := configureProducer(&conf)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -196,7 +196,7 @@ func TestConfigureProducer_InvalidVersion(t *testing.T) {
 	conf := NewKafkaConfig()
 	conf.Version = "not-a-version"
 
-	_, err := configureProducer(conf)
+	_, err := configureProducer(&conf)
 	if err == nil {
 		t.Fatal("expected error for invalid Kafka version")
 	}
@@ -206,7 +206,7 @@ func TestConfigureSasl_Disabled(t *testing.T) {
 	conf := NewKafkaConfig()
 	conf.SaslEnabled = false
 
-	saramaConf, _ := configureConsumer(conf)
+	saramaConf, _ := configureConsumer(&conf)
 	if saramaConf.Net.SASL.Enable {
 		t.Error("expected SASL to be disabled")
 	}
@@ -219,7 +219,7 @@ func TestConfigureSasl_EnabledSCRAMSHA256(t *testing.T) {
 	conf.Username = "user"
 	conf.Password = "pass"
 
-	saramaConf, _ := configureConsumer(conf)
+	saramaConf, _ := configureConsumer(&conf)
 	if !saramaConf.Net.SASL.Enable {
 		t.Error("expected SASL to be enabled")
 	}
@@ -238,7 +238,7 @@ func TestConfigureSasl_EnabledSCRAMSHA512(t *testing.T) {
 	conf.Username = "user"
 	conf.Password = "pass"
 
-	saramaConf, _ := configureConsumer(conf)
+	saramaConf, _ := configureConsumer(&conf)
 	if !saramaConf.Net.SASL.Enable {
 		t.Error("expected SASL to be enabled")
 	}
@@ -251,7 +251,7 @@ func TestConfigureTLS_DisabledDoesNothing(t *testing.T) {
 	conf := Config{TLSEnabled: false}
 	saramaConf := sarama.NewConfig()
 
-	err := configureTLS(conf, saramaConf)
+	err := configureTLS(&conf, saramaConf)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -274,7 +274,7 @@ func TestConfigureTLS_EnabledMissingCerts(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			saramaConf := sarama.NewConfig()
-			err := configureTLS(tt.conf, saramaConf)
+			err := configureTLS(&tt.conf, saramaConf)
 			if err == nil {
 				t.Fatal("expected error when TLS enabled with missing cert fields")
 			}

--- a/kafka/config_test.go
+++ b/kafka/config_test.go
@@ -1,0 +1,286 @@
+package kafka
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/IBM/sarama"
+)
+
+func TestNewKafkaConfig_Defaults(t *testing.T) {
+	conf := NewKafkaConfig()
+
+	if conf.Brokers != "localhost:9092" {
+		t.Errorf("expected Brokers 'localhost:9092', got '%s'", conf.Brokers)
+	}
+	if conf.Version != "1.1.0" {
+		t.Errorf("expected Version '1.1.0', got '%s'", conf.Version)
+	}
+	if conf.Group != "default-group" {
+		t.Errorf("expected Group 'default-group', got '%s'", conf.Group)
+	}
+	if conf.ClientID != "sarama-easy" {
+		t.Errorf("expected ClientID 'sarama-easy', got '%s'", conf.ClientID)
+	}
+	if conf.RebalanceStrategy != "roundrobin" {
+		t.Errorf("expected RebalanceStrategy 'roundrobin', got '%s'", conf.RebalanceStrategy)
+	}
+	if conf.RebalanceTimeout != 1*time.Minute {
+		t.Errorf("expected RebalanceTimeout 1m, got %v", conf.RebalanceTimeout)
+	}
+	if conf.InitOffsets != "latest" {
+		t.Errorf("expected InitOffsets 'latest', got '%s'", conf.InitOffsets)
+	}
+	if conf.CommitInterval != 10*time.Second {
+		t.Errorf("expected CommitInterval 10s, got %v", conf.CommitInterval)
+	}
+	if conf.FlushInterval != 1*time.Second {
+		t.Errorf("expected FlushInterval 1s, got %v", conf.FlushInterval)
+	}
+}
+
+func TestConfigString_MasksPassword(t *testing.T) {
+	conf := NewKafkaConfig()
+	conf.Username = "admin"
+	conf.Password = "secret123"
+
+	str := conf.String()
+
+	if strings.Contains(str, "secret123") {
+		t.Error("Config.String() should not contain the actual password")
+	}
+	if !strings.Contains(str, "****") {
+		t.Error("Config.String() should contain masked password '****'")
+	}
+	if !strings.Contains(str, "admin") {
+		t.Error("Config.String() should contain the username")
+	}
+}
+
+func TestConfigString_EmptyPassword(t *testing.T) {
+	conf := NewKafkaConfig()
+	conf.Password = ""
+
+	str := conf.String()
+
+	if strings.Contains(str, "****") {
+		t.Error("Config.String() should not mask an empty password")
+	}
+}
+
+func TestConfigureConsumer_ValidConfig(t *testing.T) {
+	conf := NewKafkaConfig()
+	conf.Topics = "test-topic"
+
+	saramaConf, err := configureConsumer(conf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if saramaConf == nil {
+		t.Fatal("expected non-nil sarama config")
+	}
+	if saramaConf.ClientID != "sarama-easy" {
+		t.Errorf("expected ClientID 'sarama-easy', got '%s'", saramaConf.ClientID)
+	}
+	if !saramaConf.Consumer.Return.Errors {
+		t.Error("expected Consumer.Return.Errors to be true")
+	}
+}
+
+func TestConfigureConsumer_InvalidVersion(t *testing.T) {
+	conf := NewKafkaConfig()
+	conf.Version = "invalid"
+
+	_, err := configureConsumer(conf)
+	if err == nil {
+		t.Fatal("expected error for invalid Kafka version")
+	}
+}
+
+func TestConfigureConsumer_InvalidRebalanceStrategy(t *testing.T) {
+	conf := NewKafkaConfig()
+	conf.RebalanceStrategy = "unknown"
+
+	_, err := configureConsumer(conf)
+	if err == nil {
+		t.Fatal("expected error for invalid rebalance strategy")
+	}
+}
+
+func TestConfigureConsumer_InvalidInitOffsets(t *testing.T) {
+	conf := NewKafkaConfig()
+	conf.InitOffsets = "invalid"
+
+	_, err := configureConsumer(conf)
+	if err == nil {
+		t.Fatal("expected error for invalid init offsets")
+	}
+}
+
+func TestConfigureConsumer_RangeStrategy(t *testing.T) {
+	conf := NewKafkaConfig()
+	conf.RebalanceStrategy = "range"
+
+	saramaConf, err := configureConsumer(conf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if saramaConf.Consumer.Group.Rebalance.Strategy == nil {
+		t.Error("expected non-nil rebalance strategy")
+	}
+}
+
+func TestConfigureConsumer_IsolationLevels(t *testing.T) {
+	tests := []struct {
+		name     string
+		level    string
+		expected int
+	}{
+		{"ReadUncommitted", "ReadUncommitted", 0},
+		{"ReadCommitted", "ReadCommitted", 1},
+		{"default", "", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conf := NewKafkaConfig()
+			conf.IsolationLevel = tt.level
+
+			saramaConf, err := configureConsumer(conf)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if int(saramaConf.Consumer.IsolationLevel) != tt.expected {
+				t.Errorf("expected isolation level %d, got %d", tt.expected, saramaConf.Consumer.IsolationLevel)
+			}
+		})
+	}
+}
+
+func TestConfigureConsumer_EarliestOffsets(t *testing.T) {
+	conf := NewKafkaConfig()
+	conf.InitOffsets = "earliest"
+
+	saramaConf, err := configureConsumer(conf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if saramaConf.Consumer.Offsets.Initial != -2 { // sarama.OffsetOldest
+		t.Errorf("expected OffsetOldest (-2), got %d", saramaConf.Consumer.Offsets.Initial)
+	}
+}
+
+func TestConfigureProducer_ValidConfig(t *testing.T) {
+	conf := NewKafkaConfig()
+
+	saramaConf, err := configureProducer(conf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if saramaConf == nil {
+		t.Fatal("expected non-nil sarama config")
+	}
+	if saramaConf.ClientID != "sarama-easy" {
+		t.Errorf("expected ClientID 'sarama-easy', got '%s'", saramaConf.ClientID)
+	}
+	if !saramaConf.Producer.Return.Errors {
+		t.Error("expected Producer.Return.Errors to be true")
+	}
+	if saramaConf.Producer.Return.Successes {
+		t.Error("expected Producer.Return.Successes to be false")
+	}
+}
+
+func TestConfigureProducer_InvalidVersion(t *testing.T) {
+	conf := NewKafkaConfig()
+	conf.Version = "not-a-version"
+
+	_, err := configureProducer(conf)
+	if err == nil {
+		t.Fatal("expected error for invalid Kafka version")
+	}
+}
+
+func TestConfigureSasl_Disabled(t *testing.T) {
+	conf := NewKafkaConfig()
+	conf.SaslEnabled = false
+
+	saramaConf, _ := configureConsumer(conf)
+	if saramaConf.Net.SASL.Enable {
+		t.Error("expected SASL to be disabled")
+	}
+}
+
+func TestConfigureSasl_EnabledSCRAMSHA256(t *testing.T) {
+	conf := NewKafkaConfig()
+	conf.SaslEnabled = true
+	conf.SaslMechanism = "SCRAM-SHA-256"
+	conf.Username = "user"
+	conf.Password = "pass"
+
+	saramaConf, _ := configureConsumer(conf)
+	if !saramaConf.Net.SASL.Enable {
+		t.Error("expected SASL to be enabled")
+	}
+	if saramaConf.Net.SASL.User != "user" {
+		t.Errorf("expected SASL user 'user', got '%s'", saramaConf.Net.SASL.User)
+	}
+	if saramaConf.Net.SASL.SCRAMClientGeneratorFunc == nil {
+		t.Error("expected SCRAM client generator to be set")
+	}
+}
+
+func TestConfigureSasl_EnabledSCRAMSHA512(t *testing.T) {
+	conf := NewKafkaConfig()
+	conf.SaslEnabled = true
+	conf.SaslMechanism = "SCRAM-SHA-512"
+	conf.Username = "user"
+	conf.Password = "pass"
+
+	saramaConf, _ := configureConsumer(conf)
+	if !saramaConf.Net.SASL.Enable {
+		t.Error("expected SASL to be enabled")
+	}
+	if saramaConf.Net.SASL.SCRAMClientGeneratorFunc == nil {
+		t.Error("expected SCRAM client generator to be set for SHA512")
+	}
+}
+
+func TestConfigureTLS_DisabledDoesNothing(t *testing.T) {
+	conf := Config{TLSEnabled: false}
+	saramaConf := sarama.NewConfig()
+
+	err := configureTLS(conf, saramaConf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if saramaConf.Net.TLS.Config != nil {
+		t.Error("expected nil TLS config when TLS is disabled")
+	}
+}
+
+func TestConfigureTLS_EnabledMissingCerts(t *testing.T) {
+	tests := []struct {
+		name string
+		conf Config
+	}{
+		{"missing all", Config{TLSEnabled: true}},
+		{"missing cert and key", Config{TLSEnabled: true, CACerts: "/tmp/ca.pem"}},
+		{"missing ca and key", Config{TLSEnabled: true, TLSCert: "/tmp/cert.pem"}},
+		{"missing ca and cert", Config{TLSEnabled: true, TLSKey: "/tmp/key.pem"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			saramaConf := sarama.NewConfig()
+			err := configureTLS(tt.conf, saramaConf)
+			if err == nil {
+				t.Fatal("expected error when TLS enabled with missing cert fields")
+			}
+			if !strings.Contains(err.Error(), "TLS enabled but") {
+				t.Errorf("unexpected error message: %s", err)
+			}
+		})
+	}
+}

--- a/kafka/consumer.go
+++ b/kafka/consumer.go
@@ -3,20 +3,25 @@ package kafka
 import (
 	"context"
 	"encoding/binary"
+	"errors"
+	"fmt"
 	"log"
 	"strings"
 
 	"github.com/IBM/sarama"
 	"github.com/linkedin/goavro/v2"
-	"github.com/pkg/errors"
 )
 
-// alias these to abstract the Sarama-specific message type from end users
+// ConsumerMessage is a type alias for sarama.ConsumerMessage, abstracting
+// the Sarama-specific message type from end users of this package.
 type ConsumerMessage sarama.ConsumerMessage
 
+// Consumer provides a high-level interface for consuming messages from Kafka
+// using consumer groups with auto-rebalancing.
 type Consumer interface {
-	// caller should run the returned function in a goroutine, and consume
-	// the returned error channel until it's closed at shutdown.
+	// Background returns a blocking function and an error channel. The caller
+	// should run the function in a goroutine and consume the error channel
+	// until it is closed (which signals shutdown is complete).
 	Background() (func(), chan error)
 }
 
@@ -25,13 +30,17 @@ type kafkaConsumer struct {
 	conf Config
 
 	consumer             sarama.ConsumerGroup
-	SchemaRegistryClient *CachedSchemaRegistryClient
+	schemaRegistryClient SchemaRegistryClientInterface
 	handler              Handler
 	errors               chan error
 
 	logger *log.Logger
 }
 
+// Message is the decoded representation of a Kafka message, passed to Handler
+// implementations. For Avro messages, Value contains the JSON-encoded Avro data
+// and SchemaId holds the Confluent Schema Registry schema ID. For non-Avro
+// messages (nil value), SchemaId is set to -1.
 type Message struct {
 	SchemaId            int
 	Topic               string
@@ -42,8 +51,14 @@ type Message struct {
 	HighWaterMarkOffset int64
 }
 
-// caller should cancel the supplied context when a graceful consumer shutdown is desired
-func NewConsumer(ctx context.Context, conf Config, handler Handler, logger *log.Logger) (Consumer, error) {
+// NewConsumer creates a Kafka consumer. The caller should cancel the supplied context for graceful shutdown.
+// Pass WithSchemaRegistryClient to share a schema registry client across multiple producers/consumers.
+func NewConsumer(ctx context.Context, conf Config, handler Handler, logger *log.Logger, opts ...Option) (Consumer, error) {
+	var o options
+	for _, opt := range opts {
+		opt(&o)
+	}
+
 	// set the internal Sarama client logging
 	if conf.Verbose {
 		sarama.Logger = logger
@@ -61,18 +76,25 @@ func NewConsumer(ctx context.Context, conf Config, handler Handler, logger *log.
 	// docs recommend 1 client per producer or consumer for throughput
 	consumer, err := sarama.NewConsumerGroup(brokers, conf.Group, saramaConf)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error creating consumer group message handler")
+		return nil, fmt.Errorf("error creating consumer group: %w", err)
 	}
 
-	// config should have a CSV list of brokers
-	schemaRegistryServers := strings.Split(conf.SchemaRegistryServers, ",")
-	schemaRegistryClient := NewCachedSchemaRegistryClient(schemaRegistryServers)
+	srClient := o.schemaRegistryClient
+	if srClient == nil {
+		schemaRegistryServers := strings.Split(conf.SchemaRegistryServers, ",")
+		if len(schemaRegistryServers) == 0 || schemaRegistryServers[0] == "" {
+			return nil, errors.New("at least one Schema Registry server is required")
+		}
+		srClient = NewCachedSchemaRegistryClientWithOptions(
+			schemaRegistryServers, len(schemaRegistryServers), conf.SchemaRegistryTimeout, 0,
+		)
+	}
 
 	return &kafkaConsumer{
 		ctx:                  ctx,
 		conf:                 conf,
 		consumer:             consumer,
-		SchemaRegistryClient: schemaRegistryClient,
+		schemaRegistryClient: srClient,
 		handler:              handler,
 		errors:               make(chan error, errorQueueSize),
 		logger:               logger,
@@ -92,7 +114,13 @@ func (kc *kafkaConsumer) Background() (func(), chan error) {
 	return func() {
 		defer func() {
 			if err := kc.consumer.Close(); err != nil {
-				kc.errors <- err
+				// Non-blocking send: during shutdown the caller may have stopped
+				// consuming the error channel, so avoid deadlock.
+				select {
+				case kc.errors <- err:
+				default:
+					kc.logger.Printf("Kafka consumer: close error dropped (channel full): %s", err)
+				}
 			}
 			// this releases the caller who should be consuming this channel
 			close(kc.errors)
@@ -101,7 +129,7 @@ func (kc *kafkaConsumer) Background() (func(), chan error) {
 		// the main consume loop, parent of the ConsumerClaim() partition message loops.
 		topics := strings.Split(kc.conf.Topics, ",")
 		for kc.ctx.Err() == nil {
-			kc.logger.Printf("Kafka consumer: begining parent Consume() loop for topic(s): %s", kc.conf.Topics)
+			kc.logger.Printf("Kafka consumer: beginning parent Consume() loop for topic(s): %s", kc.conf.Topics)
 
 			// if Consume() returns nil, a rebalance is in progress and it should be called again.
 			// if Consume() returns an error, the consumer should break the loop, shutting down.
@@ -133,7 +161,10 @@ func (kc *kafkaConsumer) ConsumeClaim(session sarama.ConsumerGroupSession, claim
 	// consume each partitions' messages async and pass to supplied handler. Messages() closed for us on shutdown
 	for msg := range claim.Messages() {
 		saramaMsg := (*ConsumerMessage)(msg)
-		message, _ := kc.ProcessAvroMsg(saramaMsg)
+		message, err := kc.ProcessAvroMsg(saramaMsg)
+		if err != nil {
+			return err
+		}
 
 		message.HighWaterMarkOffset = claim.HighWaterMarkOffset()
 		if err := kc.handler.Handle(message); err != nil {
@@ -147,6 +178,11 @@ func (kc *kafkaConsumer) ConsumeClaim(session sarama.ConsumerGroupSession, claim
 	return nil
 }
 
+// ProcessAvroMsg decodes an Avro-encoded Kafka message using the Confluent wire
+// format (magic byte + 4-byte schema ID + binary Avro payload). It fetches the
+// schema from the registry, deserializes the binary Avro data, and returns a
+// Message with the JSON-encoded value. Returns a Message with SchemaId=-1 for
+// nil-value messages (e.g. tombstones).
 func (ac *kafkaConsumer) ProcessAvroMsg(m *ConsumerMessage) (*Message, error) {
 	if m.Value == nil {
 		return &Message{
@@ -157,25 +193,30 @@ func (ac *kafkaConsumer) ProcessAvroMsg(m *ConsumerMessage) (*Message, error) {
 			Key:       string(m.Key),
 			Value:     string("")}, nil
 	}
+	if len(m.Value) < 5 {
+		return &Message{}, errors.New("message too short for Avro wire format (need at least 5 bytes)")
+	}
+	if m.Value[0] != 0x00 {
+		return &Message{}, fmt.Errorf("invalid Avro magic byte: expected 0x00, got 0x%02x", m.Value[0])
+	}
 	schemaId := binary.BigEndian.Uint32(m.Value[1:5])
-	log.Printf("SchemaID: %d", schemaId)
+	ac.logger.Printf("SchemaID: %d", schemaId)
 	codec, err := ac.GetSchema(int(schemaId))
 	if err != nil {
-		log.Printf("Error: %s", err)
+		ac.logger.Printf("Error: %s", err)
 		return &Message{}, err
 	}
 	// Convert binary Avro data back to native Go form
 	native, _, err := codec.NativeFromBinary(m.Value[5:])
 	if err != nil {
-		log.Printf("Error: %s", err)
+		ac.logger.Printf("Error: %s", err)
 		return &Message{}, err
 	}
 
 	// Convert native Go form to textual Avro data
 	textual, err := codec.TextualFromNative(nil, native)
-
 	if err != nil {
-		log.Printf("Error: %s", err)
+		ac.logger.Printf("Error: %s", err)
 		return &Message{}, err
 	}
 	msg := Message{
@@ -188,9 +229,9 @@ func (ac *kafkaConsumer) ProcessAvroMsg(m *ConsumerMessage) (*Message, error) {
 	return &msg, nil
 }
 
-// GetSchemaId get schema id from schema-registry service
+// GetSchema retrieves an Avro codec from the schema registry by its unique ID.
 func (ac *kafkaConsumer) GetSchema(id int) (*goavro.Codec, error) {
-	codec, err := ac.SchemaRegistryClient.GetSchema(id)
+	codec, err := ac.schemaRegistryClient.GetSchema(id)
 	if err != nil {
 		return nil, err
 	}

--- a/kafka/consumer.go
+++ b/kafka/consumer.go
@@ -64,7 +64,7 @@ func NewConsumer(ctx context.Context, conf Config, handler Handler, logger *log.
 		sarama.Logger = logger
 	}
 
-	saramaConf, err := configureConsumer(conf)
+	saramaConf, err := configureConsumer(&conf)
 	if err != nil {
 		return nil, err
 	}

--- a/kafka/consumer.go
+++ b/kafka/consumer.go
@@ -53,7 +53,7 @@ type Message struct {
 
 // NewConsumer creates a Kafka consumer. The caller should cancel the supplied context for graceful shutdown.
 // Pass WithSchemaRegistryClient to share a schema registry client across multiple producers/consumers.
-func NewConsumer(ctx context.Context, conf Config, handler Handler, logger *log.Logger, opts ...Option) (Consumer, error) {
+func NewConsumer(ctx context.Context, conf *Config, handler Handler, logger *log.Logger, opts ...Option) (Consumer, error) {
 	var o options
 	for _, opt := range opts {
 		opt(&o)
@@ -64,7 +64,7 @@ func NewConsumer(ctx context.Context, conf Config, handler Handler, logger *log.
 		sarama.Logger = logger
 	}
 
-	saramaConf, err := configureConsumer(&conf)
+	saramaConf, err := configureConsumer(conf)
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +92,7 @@ func NewConsumer(ctx context.Context, conf Config, handler Handler, logger *log.
 
 	return &kafkaConsumer{
 		ctx:                  ctx,
-		conf:                 conf,
+		conf:                 *conf,
 		consumer:             consumer,
 		schemaRegistryClient: srClient,
 		handler:              handler,

--- a/kafka/consumer_test.go
+++ b/kafka/consumer_test.go
@@ -1,0 +1,155 @@
+package kafka
+
+import (
+	"encoding/binary"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/IBM/sarama"
+)
+
+var testLogger = log.New(os.Stderr, "[test] ", log.LstdFlags)
+
+func TestProcessAvroMsg_NilValue(t *testing.T) {
+	kc := &kafkaConsumer{logger: testLogger}
+
+	msg := &ConsumerMessage{
+		Topic:     "test-topic",
+		Partition: 0,
+		Offset:    10,
+		Key:       []byte("test-key"),
+		Value:     nil,
+	}
+
+	result, err := kc.ProcessAvroMsg(msg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.SchemaId != -1 {
+		t.Errorf("expected SchemaId -1, got %d", result.SchemaId)
+	}
+	if result.Topic != "test-topic" {
+		t.Errorf("expected Topic 'test-topic', got '%s'", result.Topic)
+	}
+	if result.Partition != 0 {
+		t.Errorf("expected Partition 0, got %d", result.Partition)
+	}
+	if result.Offset != 10 {
+		t.Errorf("expected Offset 10, got %d", result.Offset)
+	}
+	if result.Key != "test-key" {
+		t.Errorf("expected Key 'test-key', got '%s'", result.Key)
+	}
+	if result.Value != "" {
+		t.Errorf("expected empty Value, got '%s'", result.Value)
+	}
+}
+
+func TestProcessAvroMsg_InvalidSchemaId(t *testing.T) {
+	// Create a mock cached schema registry that will fail
+	mockServers := []string{"http://localhost:1"}
+	client := NewCachedSchemaRegistryClient(mockServers)
+
+	kc := &kafkaConsumer{
+		schemaRegistryClient: client,
+		logger:               testLogger,
+	}
+
+	// Build a fake Avro message with magic byte + schema ID
+	var value []byte
+	value = append(value, byte(0)) // magic byte
+	schemaIdBytes := make([]byte, 4)
+	binary.BigEndian.PutUint32(schemaIdBytes, 99999)
+	value = append(value, schemaIdBytes...)
+	value = append(value, []byte("fake-data")...)
+
+	msg := &ConsumerMessage{
+		Topic:     "test-topic",
+		Partition: 0,
+		Offset:    1,
+		Key:       []byte("key"),
+		Value:     value,
+	}
+
+	// Should fail because schema registry is not reachable
+	_, err := kc.ProcessAvroMsg(msg)
+	if err == nil {
+		t.Fatal("expected error when schema registry is unreachable")
+	}
+}
+
+func TestProcessAvroMsg_TooShort(t *testing.T) {
+	kc := &kafkaConsumer{logger: testLogger}
+
+	msg := &ConsumerMessage{
+		Topic: "test-topic",
+		Value: []byte{0x00, 0x01}, // only 2 bytes, need at least 5
+	}
+
+	_, err := kc.ProcessAvroMsg(msg)
+	if err == nil {
+		t.Fatal("expected error for message shorter than 5 bytes")
+	}
+	if err.Error() != "message too short for Avro wire format (need at least 5 bytes)" {
+		t.Errorf("unexpected error: %s", err)
+	}
+}
+
+func TestProcessAvroMsg_InvalidMagicByte(t *testing.T) {
+	kc := &kafkaConsumer{logger: testLogger}
+
+	msg := &ConsumerMessage{
+		Topic: "test-topic",
+		Value: []byte{0x01, 0x00, 0x00, 0x00, 0x01, 0x02}, // magic byte 0x01 instead of 0x00
+	}
+
+	_, err := kc.ProcessAvroMsg(msg)
+	if err == nil {
+		t.Fatal("expected error for invalid magic byte")
+	}
+	if err.Error() != "invalid Avro magic byte: expected 0x00, got 0x01" {
+		t.Errorf("unexpected error: %s", err)
+	}
+}
+
+func TestConsumerMessage_TypeAlias(t *testing.T) {
+	saramaMsg := &sarama.ConsumerMessage{
+		Topic:     "test",
+		Partition: 1,
+		Offset:    42,
+		Key:       []byte("key"),
+		Value:     []byte("value"),
+	}
+
+	// Verify type conversion works
+	msg := (*ConsumerMessage)(saramaMsg)
+	if msg.Topic != "test" {
+		t.Errorf("expected Topic 'test', got '%s'", msg.Topic)
+	}
+	if msg.Partition != 1 {
+		t.Errorf("expected Partition 1, got %d", msg.Partition)
+	}
+	if msg.Offset != 42 {
+		t.Errorf("expected Offset 42, got %d", msg.Offset)
+	}
+}
+
+func TestMessage_Fields(t *testing.T) {
+	msg := Message{
+		SchemaId:            1,
+		Topic:               "topic",
+		Partition:           2,
+		Offset:              100,
+		Key:                 "key",
+		Value:               "value",
+		HighWaterMarkOffset: 200,
+	}
+
+	if msg.SchemaId != 1 {
+		t.Errorf("expected SchemaId 1, got %d", msg.SchemaId)
+	}
+	if msg.HighWaterMarkOffset != 200 {
+		t.Errorf("expected HighWaterMarkOffset 200, got %d", msg.HighWaterMarkOffset)
+	}
+}

--- a/kafka/doc.go
+++ b/kafka/doc.go
@@ -1,0 +1,65 @@
+// Package kafka provides a lightweight wrapper around IBM/sarama for building
+// Apache Kafka producers and consumers in Go.
+//
+// It simplifies common patterns such as async producing, consumer group
+// management with auto-rebalancing, and Avro serialization via Confluent
+// Schema Registry.
+//
+// # Quick Start
+//
+// Create a producer:
+//
+//	ctx, cancel := context.WithCancel(context.Background())
+//	defer cancel()
+//
+//	conf := kafka.NewKafkaConfig()
+//	conf.Brokers = "localhost:9092"
+//
+//	producer, err := kafka.NewProducer(ctx, conf, logger)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//
+//	processor, errors := producer.Background()
+//	go processor()
+//
+//	producer.Send(kafka.ProducerMessage{
+//	    Topic: "my-topic",
+//	    Key:   []byte("key"),
+//	    Value: []byte("value"),
+//	})
+//
+// Create a consumer:
+//
+//	consumer, err := kafka.NewConsumer(ctx, conf, myHandler, logger)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//
+//	processor, errors := consumer.Background()
+//	go processor()
+//
+//	for err := range errors {
+//	    log.Printf("error: %s", err)
+//	}
+//
+// # Configuration
+//
+// Config can be populated from environment variables using FromEnv(),
+// from code using NewKafkaConfig() with manual field assignment, or
+// via CLI flags. See the Config type for available fields and their
+// corresponding environment variable names.
+//
+// # Avro Support
+//
+// Both producer and consumer support Avro serialization using the Confluent
+// wire format (magic byte + 4-byte schema ID + binary Avro data). The
+// CachedSchemaRegistryClient provides a thread-safe, caching client for
+// Confluent Schema Registry.
+//
+// # Shutdown
+//
+// Cancel the context passed to NewProducer or NewConsumer to initiate
+// graceful shutdown. The error channel returned by Background() will be
+// closed once shutdown is complete.
+package kafka

--- a/kafka/errors_test.go
+++ b/kafka/errors_test.go
@@ -1,0 +1,48 @@
+package kafka
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"testing"
+)
+
+func TestError_Error(t *testing.T) {
+	err := &Error{ErrorCode: 40401, Message: "Subject not found"}
+	expected := "40401 - Subject not found"
+	if err.Error() != expected {
+		t.Errorf("expected '%s', got '%s'", expected, err.Error())
+	}
+}
+
+func TestNewError_ValidJSON(t *testing.T) {
+	body := `{"error_code":42202,"message":"Invalid Avro schema"}`
+	resp := &http.Response{
+		StatusCode: 422,
+		Body:       io.NopCloser(bytes.NewBufferString(body)),
+	}
+
+	err := newError(resp)
+	if err.ErrorCode != 42202 {
+		t.Errorf("expected error code 42202, got %d", err.ErrorCode)
+	}
+	if err.Message != "Invalid Avro schema" {
+		t.Errorf("expected message 'Invalid Avro schema', got '%s'", err.Message)
+	}
+}
+
+func TestNewError_InvalidJSON(t *testing.T) {
+	body := `not json`
+	resp := &http.Response{
+		StatusCode: 500,
+		Body:       io.NopCloser(bytes.NewBufferString(body)),
+	}
+
+	err := newError(resp)
+	if err.ErrorCode != 500 {
+		t.Errorf("expected error code 500, got %d", err.ErrorCode)
+	}
+	if err.Message != "Unrecognized error found" {
+		t.Errorf("expected fallback message, got '%s'", err.Message)
+	}
+}

--- a/kafka/handler.go
+++ b/kafka/handler.go
@@ -1,13 +1,15 @@
 package kafka
 
-// services consuming from Kafka should meet this contract
+// Handler is the interface that consumers use to process incoming Kafka messages.
+// Implementations receive a decoded Message and should return an error only for
+// fatal conditions that should trigger consumer shutdown.
 type Handler interface {
 	Handle(*Message) error
 }
 
+// NoOpHandler is a Handler implementation that discards all messages.
+// Useful for testing or when only side effects of consuming (e.g. offset commits) matter.
 var NoOpHandler = &noOpHandler{}
-
-// no-op message handler impl
 type noOpHandler struct{}
 
 func (h *noOpHandler) Handle(kmsg *Message) error {

--- a/kafka/handler.go
+++ b/kafka/handler.go
@@ -10,6 +10,7 @@ type Handler interface {
 // NoOpHandler is a Handler implementation that discards all messages.
 // Useful for testing or when only side effects of consuming (e.g. offset commits) matter.
 var NoOpHandler = &noOpHandler{}
+
 type noOpHandler struct{}
 
 func (h *noOpHandler) Handle(kmsg *Message) error {

--- a/kafka/handler_test.go
+++ b/kafka/handler_test.go
@@ -1,0 +1,25 @@
+package kafka
+
+import "testing"
+
+func TestNoOpHandler_Handle(t *testing.T) {
+	handler := NoOpHandler
+	msg := &Message{
+		Topic: "test",
+		Key:   "key",
+		Value: "value",
+	}
+
+	err := handler.Handle(msg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestNoOpHandler_NilMessage(t *testing.T) {
+	handler := NoOpHandler
+	err := handler.Handle(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/kafka/producer.go
+++ b/kafka/producer.go
@@ -64,7 +64,7 @@ type kafkaProducer struct {
 
 // NewProducer creates a Kafka producer. The caller can cancel the supplied context to initiate shutdown.
 // Pass WithSchemaRegistryClient to share a schema registry client across multiple producers/consumers.
-func NewProducer(ctx context.Context, conf Config, logger *log.Logger, opts ...Option) (Producer, error) {
+func NewProducer(ctx context.Context, conf *Config, logger *log.Logger, opts ...Option) (Producer, error) {
 	var o options
 	for _, opt := range opts {
 		opt(&o)
@@ -86,7 +86,7 @@ func NewProducer(ctx context.Context, conf Config, logger *log.Logger, opts ...O
 		)
 	}
 	return &kafkaProducer{
-		conf:                 conf,
+		conf:                 *conf,
 		ctx:                  ctx,
 		producer:             producer,
 		schemaRegistryClient: srClient,
@@ -169,12 +169,12 @@ func (kp *kafkaProducer) Background() (func(), chan error) {
 	}, kp.errors
 }
 
-func createProducer(conf Config, logger *log.Logger) (sarama.AsyncProducer, error) {
+func createProducer(conf *Config, logger *log.Logger) (sarama.AsyncProducer, error) {
 	if logger != nil {
 		sarama.Logger = logger
 	}
 
-	cfg, err := configureProducer(&conf)
+	cfg, err := configureProducer(conf)
 	if err != nil {
 		return nil, err
 	}

--- a/kafka/producer.go
+++ b/kafka/producer.go
@@ -3,28 +3,52 @@ package kafka
 import (
 	"context"
 	"encoding/binary"
-	"github.com/linkedin/goavro/v2"
+	"errors"
+	"fmt"
 	"log"
 	"strings"
 
 	"github.com/IBM/sarama"
-	"github.com/pkg/errors"
+	"github.com/linkedin/goavro/v2"
 )
 
-// abstracts kafka.Producer message type
+// ProducerMessage is a simplified message type for sending data to Kafka.
+// At least one of Key or Value must be non-empty.
 type ProducerMessage struct {
 	Topic string
 	Key   []byte
 	Value []byte
 }
 
+// Producer provides a high-level interface for asynchronously producing
+// messages to Kafka.
 type Producer interface {
-	// caller should run the returned function in a goroutine, and consume
-	// the returned error channel until it's closed at shutdown.
+	// Background returns a blocking function and an error channel. The caller
+	// should run the function in a goroutine and consume the error channel
+	// until it is closed (which signals shutdown is complete).
 	Background() (func(), chan error)
 
-	// user-facing event emit API
+	// Send queues a message for async delivery to Kafka. Returns an error
+	// if the message fails validation or if the context has been cancelled.
 	Send(ProducerMessage) error
+
+	// SendAvroMsg queues a pre-built sarama ProducerMessage (typically Avro-encoded
+	// using AvroEncoder) for async delivery. Returns an error if the context
+	// has been cancelled.
+	SendAvroMsg(*sarama.ProducerMessage) error
+}
+
+// Option configures optional parameters for NewProducer and NewConsumer.
+type Option func(*options)
+
+type options struct {
+	schemaRegistryClient SchemaRegistryClientInterface
+}
+
+// WithSchemaRegistryClient injects a pre-existing schema registry client,
+// allowing multiple producers/consumers to share the same client and cache.
+func WithSchemaRegistryClient(client SchemaRegistryClientInterface) Option {
+	return func(o *options) { o.schemaRegistryClient = client }
 }
 
 // internal type implementing kafka.Producer contract
@@ -33,26 +57,39 @@ type kafkaProducer struct {
 	conf Config
 
 	producer             sarama.AsyncProducer
-	SchemaRegistryClient *CachedSchemaRegistryClient
+	schemaRegistryClient SchemaRegistryClientInterface
 	errors               chan error
 	logger               *log.Logger
 }
 
-// the caller can cancel the producer's context to initiate shutdown.
-func NewProducer(ctx context.Context, conf Config, logger *log.Logger) (*kafkaProducer, error) {
+// NewProducer creates a Kafka producer. The caller can cancel the supplied context to initiate shutdown.
+// Pass WithSchemaRegistryClient to share a schema registry client across multiple producers/consumers.
+func NewProducer(ctx context.Context, conf Config, logger *log.Logger, opts ...Option) (Producer, error) {
+	var o options
+	for _, opt := range opts {
+		opt(&o)
+	}
+
 	producer, err := createProducer(conf, logger)
 	if err != nil {
 		return nil, err
 	}
 
-	// config should have a CSV list of brokers
-	schemaRegistryServers := strings.Split(conf.SchemaRegistryServers, ",")
-	schemaRegistryClient := NewCachedSchemaRegistryClient(schemaRegistryServers)
+	srClient := o.schemaRegistryClient
+	if srClient == nil {
+		schemaRegistryServers := strings.Split(conf.SchemaRegistryServers, ",")
+		if len(schemaRegistryServers) == 0 || schemaRegistryServers[0] == "" {
+			return nil, errors.New("at least one Schema Registry server is required")
+		}
+		srClient = NewCachedSchemaRegistryClientWithOptions(
+			schemaRegistryServers, len(schemaRegistryServers), conf.SchemaRegistryTimeout, 0,
+		)
+	}
 	return &kafkaProducer{
 		conf:                 conf,
 		ctx:                  ctx,
 		producer:             producer,
-		SchemaRegistryClient: schemaRegistryClient,
+		schemaRegistryClient: srClient,
 		errors:               make(chan error, errorQueueSize),
 		logger:               logger,
 	}, nil
@@ -61,11 +98,11 @@ func NewProducer(ctx context.Context, conf Config, logger *log.Logger) (*kafkaPr
 // user-facing event emit API
 func (kp *kafkaProducer) Send(msg ProducerMessage) error {
 	if len(msg.Topic) == 0 {
-		return errors.New("message Topic is required")
+		return errors.New("message topic is required")
 	}
 
 	if len(msg.Key) == 0 && len(msg.Value) == 0 {
-		return errors.New("at least one of message fields Key or Value is required")
+		return errors.New("at least one of message fields key or value is required")
 	}
 
 	kmsg := &sarama.ProducerMessage{
@@ -77,7 +114,7 @@ func (kp *kafkaProducer) Send(msg ProducerMessage) error {
 	// if shutdown is triggered, drop the message
 	select {
 	case <-kp.ctx.Done():
-		return errors.Wrapf(kp.ctx.Err(), "message lost: shutdown triggered during send")
+		return fmt.Errorf("message lost: shutdown triggered during send: %w", kp.ctx.Err())
 
 	case kp.producer.Input() <- kmsg:
 		// fall through, msg has been queued for write
@@ -92,7 +129,7 @@ func (kp *kafkaProducer) SendAvroMsg(msg *sarama.ProducerMessage) error {
 	// if shutdown is triggered, drop the message
 	select {
 	case <-kp.ctx.Done():
-		return errors.Wrapf(kp.ctx.Err(), "message lost: shutdown triggered during send")
+		return fmt.Errorf("message lost: shutdown triggered during send: %w", kp.ctx.Err())
 
 	case kp.producer.Input() <- msg:
 		// fall through, msg has been queued for write
@@ -115,7 +152,15 @@ func (kp *kafkaProducer) Background() (func(), chan error) {
 
 	return func() {
 		defer func() {
-			kp.errors <- kp.producer.Close()
+			if err := kp.producer.Close(); err != nil {
+				// Non-blocking send: during shutdown the caller may have stopped
+				// consuming the error channel, so avoid deadlock.
+				select {
+				case kp.errors <- err:
+				default:
+					kp.logger.Printf("Kafka producer: close error dropped (channel full): %s", err)
+				}
+			}
 			close(kp.errors)
 		}()
 
@@ -137,13 +182,15 @@ func createProducer(conf Config, logger *log.Logger) (sarama.AsyncProducer, erro
 	brokers := strings.Split(conf.Brokers, ",")
 	producer, err := sarama.NewAsyncProducer(brokers, cfg)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to create Kafka producer")
+		return nil, fmt.Errorf("failed to create Kafka producer: %w", err)
 	}
 
 	return producer, nil
 }
 
-// AvroEncoder encodes schemaId and Avro message.
+// AvroEncoder implements sarama.Encoder for Avro messages using the Confluent
+// wire format: 1 magic byte (0x00) + 4-byte big-endian schema ID + binary Avro payload.
+// Use this with sarama.ProducerMessage to send Avro-encoded messages.
 type AvroEncoder struct {
 	SchemaID int
 	Content  []byte
@@ -170,9 +217,10 @@ func (a *AvroEncoder) Length() int {
 	return 5 + len(a.Content)
 }
 
-// GetSchemaId get schema id from schema-registry service
+// GetSchemaId registers or retrieves the schema ID for the given topic from
+// the schema registry. The subject name is derived as "<topic>-value".
 func (ap *kafkaProducer) GetSchemaId(topic string, avroCodec *goavro.Codec) (int, error) {
-	schemaId, err := ap.SchemaRegistryClient.CreateSubject(topic+"-value", avroCodec)
+	schemaId, err := ap.schemaRegistryClient.CreateSubject(topic+"-value", avroCodec)
 	if err != nil {
 		return 0, err
 	}

--- a/kafka/producer.go
+++ b/kafka/producer.go
@@ -174,7 +174,7 @@ func createProducer(conf Config, logger *log.Logger) (sarama.AsyncProducer, erro
 		sarama.Logger = logger
 	}
 
-	cfg, err := configureProducer(conf)
+	cfg, err := configureProducer(&conf)
 	if err != nil {
 		return nil, err
 	}

--- a/kafka/producer_test.go
+++ b/kafka/producer_test.go
@@ -1,0 +1,130 @@
+package kafka
+
+import (
+	"context"
+	"encoding/binary"
+	"testing"
+)
+
+func TestSend_EmptyTopic(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	kp := &kafkaProducer{
+		ctx: ctx,
+	}
+
+	err := kp.Send(ProducerMessage{
+		Topic: "",
+		Key:   []byte("key"),
+		Value: []byte("value"),
+	})
+	if err == nil {
+		t.Fatal("expected error for empty topic")
+	}
+	if err.Error() != "message topic is required" {
+		t.Errorf("unexpected error message: %s", err)
+	}
+}
+
+func TestSend_EmptyKeyAndValue(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	kp := &kafkaProducer{
+		ctx: ctx,
+	}
+
+	err := kp.Send(ProducerMessage{
+		Topic: "test-topic",
+		Key:   []byte{},
+		Value: []byte{},
+	})
+	if err == nil {
+		t.Fatal("expected error for empty key and value")
+	}
+	if err.Error() != "at least one of message fields key or value is required" {
+		t.Errorf("unexpected error message: %s", err)
+	}
+}
+
+func TestSend_ValidationBeforeProducer(t *testing.T) {
+	// Validation should happen before touching the producer,
+	// so even with nil producer these should return proper errors
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	kp := &kafkaProducer{ctx: ctx}
+
+	err := kp.Send(ProducerMessage{Topic: "", Key: []byte("k")})
+	if err == nil {
+		t.Fatal("expected error for empty topic")
+	}
+
+	err = kp.Send(ProducerMessage{Topic: "t"})
+	if err == nil {
+		t.Fatal("expected error for empty key and value")
+	}
+}
+
+func TestAvroEncoder_Encode(t *testing.T) {
+	content := []byte("test-avro-data")
+	encoder := &AvroEncoder{
+		SchemaID: 42,
+		Content:  content,
+	}
+
+	encoded, err := encoder.Encode()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// First byte should be magic byte 0
+	if encoded[0] != 0 {
+		t.Errorf("expected magic byte 0, got %d", encoded[0])
+	}
+
+	// Bytes 1-4 should be schema ID in big-endian
+	schemaId := binary.BigEndian.Uint32(encoded[1:5])
+	if schemaId != 42 {
+		t.Errorf("expected schema ID 42, got %d", schemaId)
+	}
+
+	// Remaining bytes should be the content
+	if string(encoded[5:]) != "test-avro-data" {
+		t.Errorf("expected content 'test-avro-data', got '%s'", string(encoded[5:]))
+	}
+}
+
+func TestAvroEncoder_Length(t *testing.T) {
+	encoder := &AvroEncoder{
+		SchemaID: 1,
+		Content:  []byte("hello"),
+	}
+
+	// 5 bytes header (1 magic + 4 schema ID) + content length
+	expected := 5 + len("hello")
+	if encoder.Length() != expected {
+		t.Errorf("expected length %d, got %d", expected, encoder.Length())
+	}
+}
+
+func TestAvroEncoder_EmptyContent(t *testing.T) {
+	encoder := &AvroEncoder{
+		SchemaID: 1,
+		Content:  []byte{},
+	}
+
+	encoded, err := encoder.Encode()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(encoded) != 5 {
+		t.Errorf("expected 5 bytes for empty content, got %d", len(encoded))
+	}
+
+	if encoder.Length() != 5 {
+		t.Errorf("expected length 5, got %d", encoder.Length())
+	}
+}

--- a/kafka/schemaRegistry.go
+++ b/kafka/schemaRegistry.go
@@ -220,11 +220,14 @@ func (client *SchemaRegistryClient) httpCall(method, uri string, payload io.Read
 		if err != nil {
 			return nil, err
 		}
-		defer resp.Body.Close()
-		if !okStatus(resp) {
-			return nil, newError(resp)
-		}
-		return io.ReadAll(resp.Body)
+		body, err := func() ([]byte, error) {
+			defer resp.Body.Close()
+			if !okStatus(resp) {
+				return nil, newError(resp)
+			}
+			return io.ReadAll(resp.Body)
+		}()
+		return body, err
 	}
 }
 

--- a/kafka/schemaRegistry.go
+++ b/kafka/schemaRegistry.go
@@ -4,15 +4,17 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/linkedin/goavro/v2"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"time"
+
+	"github.com/linkedin/goavro/v2"
 )
 
-// SchemaRegistryClientInterface defines the api for all clients interfacing with schema registry
+// SchemaRegistryClientInterface defines the contract for clients that interact
+// with Confluent Schema Registry. Both SchemaRegistryClient and
+// CachedSchemaRegistryClient implement this interface.
 type SchemaRegistryClientInterface interface {
 	GetSchema(int) (*goavro.Codec, error)
 	GetSubjects() ([]string, error)
@@ -25,7 +27,8 @@ type SchemaRegistryClientInterface interface {
 	DeleteVersion(string, int) error
 }
 
-// SchemaRegistryClient is a basic http client to interact with schema registry
+// SchemaRegistryClient is an HTTP client for the Confluent Schema Registry REST API.
+// It supports automatic retries on 5XX errors with round-robin server selection.
 type SchemaRegistryClient struct {
 	SchemaRegistryConnect []string
 	httpClient            *http.Client
@@ -58,20 +61,26 @@ const (
 
 	contentType = "application/vnd.schemaregistry.v1+json"
 
-	timeout = 2 * time.Second
+	defaultTimeout = 2 * time.Second
 )
 
-// NewSchemaRegistryClient creates a client to talk with the schema registry at the connect string
-// By default it will retry failed requests (5XX responses and http errors) len(connect) number of times
+// NewSchemaRegistryClient creates a client to talk with the schema registry at the connect string.
+// By default it will retry failed requests (5XX responses and http errors) len(connect) number of times.
 func NewSchemaRegistryClient(connect []string) *SchemaRegistryClient {
-	client := &http.Client{
-		Timeout: timeout,
-	}
-	return &SchemaRegistryClient{connect, client, len(connect)}
+	return NewSchemaRegistryClientWithOptions(connect, len(connect), 0)
 }
 
-// NewSchemaRegistryClientWithRetries creates an http client with a configurable amount of retries on 5XX responses
+// NewSchemaRegistryClientWithRetries creates an http client with a configurable amount of retries on 5XX responses.
 func NewSchemaRegistryClientWithRetries(connect []string, retries int) *SchemaRegistryClient {
+	return NewSchemaRegistryClientWithOptions(connect, retries, 0)
+}
+
+// NewSchemaRegistryClientWithOptions creates a client with configurable retries and timeout.
+// A zero timeout uses the default of 2 seconds.
+func NewSchemaRegistryClientWithOptions(connect []string, retries int, timeout time.Duration) *SchemaRegistryClient {
+	if timeout <= 0 {
+		timeout = defaultTimeout
+	}
 	client := &http.Client{
 		Timeout: timeout,
 	}
@@ -81,11 +90,11 @@ func NewSchemaRegistryClientWithRetries(connect []string, retries int) *SchemaRe
 // GetSchema returns a goavro.Codec by unique id
 func (client *SchemaRegistryClient) GetSchema(id int) (*goavro.Codec, error) {
 	resp, err := client.httpCall("GET", fmt.Sprintf(schemaByID, id), nil)
-	if nil != err {
+	if err != nil {
 		return nil, err
 	}
 	schema, err := parseSchema(resp)
-	if nil != err {
+	if err != nil {
 		return nil, err
 	}
 	return goavro.NewCodec(schema.Schema)
@@ -94,7 +103,7 @@ func (client *SchemaRegistryClient) GetSchema(id int) (*goavro.Codec, error) {
 // GetSubjects returns a list of all subjects in the schema registry
 func (client *SchemaRegistryClient) GetSubjects() ([]string, error) {
 	resp, err := client.httpCall("GET", subjects, nil)
-	if nil != err {
+	if err != nil {
 		return []string{}, err
 	}
 	var result = []string{}
@@ -105,7 +114,7 @@ func (client *SchemaRegistryClient) GetSubjects() ([]string, error) {
 // GetVersions returns a list of the versions of a subject
 func (client *SchemaRegistryClient) GetVersions(subject string) ([]int, error) {
 	resp, err := client.httpCall("GET", fmt.Sprintf(subjectVersions, subject), nil)
-	if nil != err {
+	if err != nil {
 		return []int{}, err
 	}
 	var result = []int{}
@@ -115,12 +124,12 @@ func (client *SchemaRegistryClient) GetVersions(subject string) ([]int, error) {
 
 func (client *SchemaRegistryClient) getSchemaByVersionInternal(subject string, version string) (*goavro.Codec, error) {
 	resp, err := client.httpCall("GET", fmt.Sprintf(subjectByVersion, subject, version), nil)
-	if nil != err {
+	if err != nil {
 		return nil, err
 	}
 	var schema = new(schemaVersionResponse)
 	err = json.Unmarshal(resp, &schema)
-	if nil != err {
+	if err != nil {
 		return nil, err
 	}
 
@@ -202,19 +211,20 @@ func (client *SchemaRegistryClient) httpCall(method, uri string, payload io.Read
 		}
 		req.Header.Set("Content-Type", contentType)
 		resp, err := client.httpClient.Do(req)
-		if resp != nil {
-			defer resp.Body.Close()
-		}
 		if i < client.retries && (err != nil || retriable(resp)) {
+			if resp != nil {
+				resp.Body.Close()
+			}
 			continue
 		}
 		if err != nil {
 			return nil, err
 		}
+		defer resp.Body.Close()
 		if !okStatus(resp) {
 			return nil, newError(resp)
 		}
-		return ioutil.ReadAll(resp.Body)
+		return io.ReadAll(resp.Body)
 	}
 }
 

--- a/kafka/schemaRegistry_test.go
+++ b/kafka/schemaRegistry_test.go
@@ -25,7 +25,7 @@ func TestGetSchema_Success(t *testing.T) {
 			t.Errorf("unexpected path: %s", r.URL.Path)
 		}
 		resp := schemaResponse{Schema: avroSchema}
-		json.NewEncoder(w).Encode(resp)
+		_ = json.NewEncoder(w).Encode(resp)
 	})
 	defer server.Close()
 
@@ -42,7 +42,7 @@ func TestGetSchema_Success(t *testing.T) {
 func TestGetSchema_NotFound(t *testing.T) {
 	server := newTestServer(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
-		json.NewEncoder(w).Encode(Error{ErrorCode: 40403, Message: "Schema not found"})
+		_ = json.NewEncoder(w).Encode(Error{ErrorCode: 40403, Message: "Schema not found"})
 	})
 	defer server.Close()
 
@@ -58,7 +58,7 @@ func TestGetSubjects_Success(t *testing.T) {
 		if r.URL.Path != "/subjects" {
 			t.Errorf("unexpected path: %s", r.URL.Path)
 		}
-		json.NewEncoder(w).Encode([]string{"subject1", "subject2"})
+		_ = json.NewEncoder(w).Encode([]string{"subject1", "subject2"})
 	})
 	defer server.Close()
 
@@ -80,7 +80,7 @@ func TestGetVersions_Success(t *testing.T) {
 		if r.URL.Path != "/subjects/test-subject/versions" {
 			t.Errorf("unexpected path: %s", r.URL.Path)
 		}
-		json.NewEncoder(w).Encode([]int{1, 2, 3})
+		_ = json.NewEncoder(w).Encode([]int{1, 2, 3})
 	})
 	defer server.Close()
 
@@ -103,7 +103,7 @@ func TestGetSchemaByVersion_Success(t *testing.T) {
 			Schema:  avroSchema,
 			ID:      10,
 		}
-		json.NewEncoder(w).Encode(resp)
+		_ = json.NewEncoder(w).Encode(resp)
 	})
 	defer server.Close()
 
@@ -129,7 +129,7 @@ func TestGetLatestSchema_Success(t *testing.T) {
 			Schema:  avroSchema,
 			ID:      10,
 		}
-		json.NewEncoder(w).Encode(resp)
+		_ = json.NewEncoder(w).Encode(resp)
 	})
 	defer server.Close()
 
@@ -148,7 +148,7 @@ func TestCreateSubject_Success(t *testing.T) {
 		if r.Method != "POST" {
 			t.Errorf("expected POST, got %s", r.Method)
 		}
-		json.NewEncoder(w).Encode(idResponse{ID: 42})
+		_ = json.NewEncoder(w).Encode(idResponse{ID: 42})
 	})
 	defer server.Close()
 
@@ -173,7 +173,7 @@ func TestDeleteSubject_Success(t *testing.T) {
 		if r.URL.Path != "/subjects/test-subject" {
 			t.Errorf("unexpected path: %s", r.URL.Path)
 		}
-		json.NewEncoder(w).Encode([]int{1, 2})
+		_ = json.NewEncoder(w).Encode([]int{1, 2})
 	})
 	defer server.Close()
 
@@ -209,7 +209,7 @@ func TestHttpCall_Retry5XX(t *testing.T) {
 			w.WriteHeader(http.StatusServiceUnavailable)
 			return
 		}
-		json.NewEncoder(w).Encode([]string{"ok"})
+		_ = json.NewEncoder(w).Encode([]string{"ok"})
 	})
 	defer server.Close()
 
@@ -232,12 +232,12 @@ func TestHttpCall_ContentType(t *testing.T) {
 		if ct != contentType {
 			t.Errorf("expected content type '%s', got '%s'", contentType, ct)
 		}
-		json.NewEncoder(w).Encode([]string{})
+		_ = json.NewEncoder(w).Encode([]string{})
 	})
 	defer server.Close()
 
 	client := NewSchemaRegistryClient([]string{server.URL})
-	client.GetSubjects()
+	_, _ = client.GetSubjects()
 }
 
 func TestRetriable(t *testing.T) {
@@ -292,7 +292,7 @@ func TestCachedGetSchema_CachesResult(t *testing.T) {
 	server := newTestServer(func(w http.ResponseWriter, r *http.Request) {
 		calls++
 		resp := schemaResponse{Schema: avroSchema}
-		json.NewEncoder(w).Encode(resp)
+		_ = json.NewEncoder(w).Encode(resp)
 	})
 	defer server.Close()
 
@@ -327,7 +327,7 @@ func TestCachedCreateSubject_CachesResult(t *testing.T) {
 	calls := 0
 	server := newTestServer(func(w http.ResponseWriter, r *http.Request) {
 		calls++
-		json.NewEncoder(w).Encode(idResponse{ID: 7})
+		_ = json.NewEncoder(w).Encode(idResponse{ID: 7})
 	})
 	defer server.Close()
 
@@ -373,7 +373,7 @@ func TestCachedGetSchema_ConcurrentDoubleCheck(t *testing.T) {
 		calls++
 		// Simulate slow response to increase contention window
 		resp := schemaResponse{Schema: avroSchema}
-		json.NewEncoder(w).Encode(resp)
+		_ = json.NewEncoder(w).Encode(resp)
 	})
 	defer server.Close()
 
@@ -416,7 +416,7 @@ func TestCachedGetSchema_TTLExpiration(t *testing.T) {
 	server := newTestServer(func(w http.ResponseWriter, r *http.Request) {
 		calls++
 		resp := schemaResponse{Schema: avroSchema}
-		json.NewEncoder(w).Encode(resp)
+		_ = json.NewEncoder(w).Encode(resp)
 	})
 	defer server.Close()
 

--- a/kafka/schemaRegistry_test.go
+++ b/kafka/schemaRegistry_test.go
@@ -1,0 +1,478 @@
+package kafka
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/linkedin/goavro/v2"
+)
+
+func newTestServer(handler http.HandlerFunc) *httptest.Server {
+	return httptest.NewServer(handler)
+}
+
+func TestGetSchema_Success(t *testing.T) {
+	avroSchema := `{"type":"string"}`
+	server := newTestServer(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/schemas/ids/1" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		resp := schemaResponse{Schema: avroSchema}
+		json.NewEncoder(w).Encode(resp)
+	})
+	defer server.Close()
+
+	client := NewSchemaRegistryClient([]string{server.URL})
+	codec, err := client.GetSchema(1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if codec == nil {
+		t.Fatal("expected non-nil codec")
+	}
+}
+
+func TestGetSchema_NotFound(t *testing.T) {
+	server := newTestServer(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(Error{ErrorCode: 40403, Message: "Schema not found"})
+	})
+	defer server.Close()
+
+	client := NewSchemaRegistryClient([]string{server.URL})
+	_, err := client.GetSchema(999)
+	if err == nil {
+		t.Fatal("expected error for missing schema")
+	}
+}
+
+func TestGetSubjects_Success(t *testing.T) {
+	server := newTestServer(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/subjects" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		json.NewEncoder(w).Encode([]string{"subject1", "subject2"})
+	})
+	defer server.Close()
+
+	client := NewSchemaRegistryClient([]string{server.URL})
+	subjects, err := client.GetSubjects()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(subjects) != 2 {
+		t.Errorf("expected 2 subjects, got %d", len(subjects))
+	}
+	if subjects[0] != "subject1" {
+		t.Errorf("expected 'subject1', got '%s'", subjects[0])
+	}
+}
+
+func TestGetVersions_Success(t *testing.T) {
+	server := newTestServer(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/subjects/test-subject/versions" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		json.NewEncoder(w).Encode([]int{1, 2, 3})
+	})
+	defer server.Close()
+
+	client := NewSchemaRegistryClient([]string{server.URL})
+	versions, err := client.GetVersions("test-subject")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(versions) != 3 {
+		t.Errorf("expected 3 versions, got %d", len(versions))
+	}
+}
+
+func TestGetSchemaByVersion_Success(t *testing.T) {
+	avroSchema := `{"type":"string"}`
+	server := newTestServer(func(w http.ResponseWriter, r *http.Request) {
+		resp := schemaVersionResponse{
+			Subject: "test",
+			Version: 1,
+			Schema:  avroSchema,
+			ID:      10,
+		}
+		json.NewEncoder(w).Encode(resp)
+	})
+	defer server.Close()
+
+	client := NewSchemaRegistryClient([]string{server.URL})
+	codec, err := client.GetSchemaByVersion("test", 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if codec == nil {
+		t.Fatal("expected non-nil codec")
+	}
+}
+
+func TestGetLatestSchema_Success(t *testing.T) {
+	avroSchema := `{"type":"string"}`
+	server := newTestServer(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/subjects/test/versions/latest" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		resp := schemaVersionResponse{
+			Subject: "test",
+			Version: 3,
+			Schema:  avroSchema,
+			ID:      10,
+		}
+		json.NewEncoder(w).Encode(resp)
+	})
+	defer server.Close()
+
+	client := NewSchemaRegistryClient([]string{server.URL})
+	codec, err := client.GetLatestSchema("test")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if codec == nil {
+		t.Fatal("expected non-nil codec")
+	}
+}
+
+func TestCreateSubject_Success(t *testing.T) {
+	server := newTestServer(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		json.NewEncoder(w).Encode(idResponse{ID: 42})
+	})
+	defer server.Close()
+
+	client := NewSchemaRegistryClient([]string{server.URL})
+
+	// goavro needs a valid schema to create a codec
+	codec, _ := newTestCodec()
+	id, err := client.CreateSubject("test-subject", codec)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id != 42 {
+		t.Errorf("expected ID 42, got %d", id)
+	}
+}
+
+func TestDeleteSubject_Success(t *testing.T) {
+	server := newTestServer(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "DELETE" {
+			t.Errorf("expected DELETE, got %s", r.Method)
+		}
+		if r.URL.Path != "/subjects/test-subject" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		json.NewEncoder(w).Encode([]int{1, 2})
+	})
+	defer server.Close()
+
+	client := NewSchemaRegistryClient([]string{server.URL})
+	err := client.DeleteSubject("test-subject")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDeleteVersion_Success(t *testing.T) {
+	server := newTestServer(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "DELETE" {
+			t.Errorf("expected DELETE, got %s", r.Method)
+		}
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "1")
+	})
+	defer server.Close()
+
+	client := NewSchemaRegistryClient([]string{server.URL})
+	err := client.DeleteVersion("test-subject", 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestHttpCall_Retry5XX(t *testing.T) {
+	attempts := 0
+	server := newTestServer(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if attempts < 3 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		json.NewEncoder(w).Encode([]string{"ok"})
+	})
+	defer server.Close()
+
+	client := NewSchemaRegistryClientWithRetries([]string{server.URL}, 3)
+	subjects, err := client.GetSubjects()
+	if err != nil {
+		t.Fatalf("unexpected error after retries: %v", err)
+	}
+	if len(subjects) != 1 {
+		t.Errorf("expected 1 subject, got %d", len(subjects))
+	}
+	if attempts != 3 {
+		t.Errorf("expected 3 attempts, got %d", attempts)
+	}
+}
+
+func TestHttpCall_ContentType(t *testing.T) {
+	server := newTestServer(func(w http.ResponseWriter, r *http.Request) {
+		ct := r.Header.Get("Content-Type")
+		if ct != contentType {
+			t.Errorf("expected content type '%s', got '%s'", contentType, ct)
+		}
+		json.NewEncoder(w).Encode([]string{})
+	})
+	defer server.Close()
+
+	client := NewSchemaRegistryClient([]string{server.URL})
+	client.GetSubjects()
+}
+
+func TestRetriable(t *testing.T) {
+	tests := []struct {
+		code     int
+		expected bool
+	}{
+		{200, false},
+		{404, false},
+		{500, true},
+		{502, true},
+		{503, true},
+		{599, true},
+		{600, false},
+	}
+
+	for _, tt := range tests {
+		resp := &http.Response{StatusCode: tt.code}
+		if retriable(resp) != tt.expected {
+			t.Errorf("retriable(%d) = %v, want %v", tt.code, !tt.expected, tt.expected)
+		}
+	}
+}
+
+func TestOkStatus(t *testing.T) {
+	tests := []struct {
+		code     int
+		expected bool
+	}{
+		{200, true},
+		{201, true},
+		{301, true},
+		{399, true},
+		{400, false},
+		{404, false},
+		{500, false},
+	}
+
+	for _, tt := range tests {
+		resp := &http.Response{StatusCode: tt.code}
+		if okStatus(resp) != tt.expected {
+			t.Errorf("okStatus(%d) = %v, want %v", tt.code, !tt.expected, tt.expected)
+		}
+	}
+}
+
+// --- Cached Schema Registry Tests ---
+
+func TestCachedGetSchema_CachesResult(t *testing.T) {
+	avroSchema := `{"type":"string"}`
+	calls := 0
+	server := newTestServer(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		resp := schemaResponse{Schema: avroSchema}
+		json.NewEncoder(w).Encode(resp)
+	})
+	defer server.Close()
+
+	client := NewCachedSchemaRegistryClient([]string{server.URL})
+
+	// First call should hit the server
+	codec1, err := client.GetSchema(1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if codec1 == nil {
+		t.Fatal("expected non-nil codec")
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 server call, got %d", calls)
+	}
+
+	// Second call should be cached
+	codec2, err := client.GetSchema(1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if codec2 == nil {
+		t.Fatal("expected non-nil codec from cache")
+	}
+	if calls != 1 {
+		t.Errorf("expected still 1 server call (cached), got %d", calls)
+	}
+}
+
+func TestCachedCreateSubject_CachesResult(t *testing.T) {
+	calls := 0
+	server := newTestServer(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		json.NewEncoder(w).Encode(idResponse{ID: 7})
+	})
+	defer server.Close()
+
+	client := NewCachedSchemaRegistryClient([]string{server.URL})
+	codec, _ := newTestCodec()
+
+	// First call
+	id1, err := client.CreateSubject("test", codec)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id1 != 7 {
+		t.Errorf("expected ID 7, got %d", id1)
+	}
+
+	// Second call should be cached
+	id2, err := client.CreateSubject("test", codec)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id2 != 7 {
+		t.Errorf("expected cached ID 7, got %d", id2)
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 server call (cached), got %d", calls)
+	}
+}
+
+func TestCachedSchemaRegistryClientWithRetries(t *testing.T) {
+	client := NewCachedSchemaRegistryClientWithRetries([]string{"http://localhost:1"}, 5)
+	if client == nil {
+		t.Fatal("expected non-nil client")
+	}
+	if client.schemaRegistryClient.retries != 5 {
+		t.Errorf("expected 5 retries, got %d", client.schemaRegistryClient.retries)
+	}
+}
+
+func TestCachedGetSchema_ConcurrentDoubleCheck(t *testing.T) {
+	avroSchema := `{"type":"string"}`
+	calls := 0
+	server := newTestServer(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		// Simulate slow response to increase contention window
+		resp := schemaResponse{Schema: avroSchema}
+		json.NewEncoder(w).Encode(resp)
+	})
+	defer server.Close()
+
+	client := NewCachedSchemaRegistryClient([]string{server.URL})
+
+	// Launch multiple goroutines requesting the same schema concurrently
+	const goroutines = 20
+	errs := make(chan error, goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			codec, err := client.GetSchema(1)
+			if err != nil {
+				errs <- err
+				return
+			}
+			if codec == nil {
+				errs <- fmt.Errorf("expected non-nil codec")
+				return
+			}
+			errs <- nil
+		}()
+	}
+
+	for i := 0; i < goroutines; i++ {
+		if err := <-errs; err != nil {
+			t.Fatalf("goroutine error: %v", err)
+		}
+	}
+
+	// With double-check locking, only 1 HTTP call should be made
+	// (the first goroutine to acquire the write lock fetches, others find it cached)
+	if calls != 1 {
+		t.Errorf("expected 1 server call with double-check locking, got %d", calls)
+	}
+}
+
+func TestCachedGetSchema_TTLExpiration(t *testing.T) {
+	avroSchema := `{"type":"string"}`
+	calls := 0
+	server := newTestServer(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		resp := schemaResponse{Schema: avroSchema}
+		json.NewEncoder(w).Encode(resp)
+	})
+	defer server.Close()
+
+	client := NewCachedSchemaRegistryClientWithOptions(
+		[]string{server.URL}, 1, 2*time.Second, 50*time.Millisecond,
+	)
+
+	// First call hits server
+	_, err := client.GetSchema(1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected 1 call, got %d", calls)
+	}
+
+	// Second call is cached
+	_, err = client.GetSchema(1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected still 1 call (cached), got %d", calls)
+	}
+
+	// Wait for TTL to expire
+	time.Sleep(60 * time.Millisecond)
+
+	// Third call should re-fetch
+	_, err = client.GetSchema(1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 2 {
+		t.Errorf("expected 2 calls after TTL expiry, got %d", calls)
+	}
+}
+
+func TestNewSchemaRegistryClientWithOptions_CustomTimeout(t *testing.T) {
+	client := NewSchemaRegistryClientWithOptions([]string{"http://localhost:1"}, 3, 5*time.Second)
+	if client.httpClient.Timeout != 5*time.Second {
+		t.Errorf("expected 5s timeout, got %v", client.httpClient.Timeout)
+	}
+	if client.retries != 3 {
+		t.Errorf("expected 3 retries, got %d", client.retries)
+	}
+}
+
+func TestNewSchemaRegistryClientWithOptions_DefaultTimeout(t *testing.T) {
+	client := NewSchemaRegistryClientWithOptions([]string{"http://localhost:1"}, 1, 0)
+	if client.httpClient.Timeout != 2*time.Second {
+		t.Errorf("expected default 2s timeout, got %v", client.httpClient.Timeout)
+	}
+}
+
+// helper to create a valid goavro Codec for testing
+func newTestCodec() (*goavro.Codec, error) {
+	return goavro.NewCodec(`{"type":"string"}`)
+}


### PR DESCRIPTION
## Summary
- **Security**: Fix critical TLS validation bug, add Avro bounds check to prevent panics, validate Schema Registry URLs
- **Code quality**: Migrate from deprecated `pkg/errors` to Go native `fmt.Errorf` with `%w`, fix inconsistent logging, add 7 new tests (52 total)
- **Architecture**: Configurable Schema Registry timeout, cache TTL support, shared SR client via `WithSchemaRegistryClient` option
- **DevOps**: Multi-stage Dockerfile (distroless ~20MB), GitHub Actions CI, `.golangci.yml`, Makefile

## Test plan
- [x] `go test -race -count=1 ./...` — 52 tests pass with race detector
- [x] `go vet ./...` — no warnings
- [x] `go build ./...` — compiles cleanly
- [ ] Verify GitHub Actions CI runs on this PR
- [ ] Test with live Kafka cluster via `docker-compose up`