### PR TITLE
Allow TLS without mTLS for AWS MSK with public CAs

### DIFF
--- a/kafka/config.go
+++ b/kafka/config.go
@@ -230,14 +230,30 @@ func configureProducer(envConf *Config) (*sarama.Config, error) {
 	return saramaConf, nil
 }
 
-// side effect TLS setup into Sarama config if env config specifies to do so
+// configureTLS sets up TLS on the Sarama config. When TLS is enabled but no
+// custom certificates are provided, it uses the system trust store (suitable
+// for brokers with public CA certificates, e.g. AWS MSK with SASL_SSL).
+// When all three cert fields are set, it configures mutual TLS (mTLS).
 func configureTLS(envConf *Config, saramaConf *sarama.Config) error {
 	if !envConf.TLSEnabled {
 		return nil
 	}
 
-	if envConf.CACerts == "" || envConf.TLSCert == "" || envConf.TLSKey == "" {
-		return errors.New("TLS enabled but CACerts, TLSCert, and TLSKey are all required")
+	hasCACerts := envConf.CACerts != ""
+	hasTLSCert := envConf.TLSCert != ""
+	hasTLSKey := envConf.TLSKey != ""
+
+	// No custom certs: use system CA trust store (e.g. AWS MSK with public CAs)
+	if !hasCACerts && !hasTLSCert && !hasTLSKey {
+		saramaConf.Net.TLS.Config = &tls.Config{
+			MinVersion: tls.VersionTLS12,
+		}
+		return nil
+	}
+
+	// Partial config: all three must be provided for mTLS
+	if !hasCACerts || !hasTLSCert || !hasTLSKey {
+		return errors.New("mTLS requires all three: CACerts, TLSCert, and TLSKey")
 	}
 
 	cert, err := tls.LoadX509KeyPair(envConf.TLSCert, envConf.TLSKey)
@@ -255,12 +271,10 @@ func configureTLS(envConf *Config, saramaConf *sarama.Config) error {
 		return fmt.Errorf("CA cert bundle at %s contains no valid PEM certificates", envConf.CACerts)
 	}
 
-	tlsCfg := &tls.Config{
+	saramaConf.Net.TLS.Config = &tls.Config{
 		Certificates: []tls.Certificate{cert},
 		RootCAs:      pool,
 		MinVersion:   tls.VersionTLS12,
 	}
-
-	saramaConf.Net.TLS.Config = tlsCfg
 	return nil
 }

--- a/kafka/config_test.go
+++ b/kafka/config_test.go
@@ -260,12 +260,30 @@ func TestConfigureTLS_DisabledDoesNothing(t *testing.T) {
 	}
 }
 
-func TestConfigureTLS_EnabledMissingCerts(t *testing.T) {
+func TestConfigureTLS_EnabledNoCerts_UsesSystemCA(t *testing.T) {
+	conf := Config{TLSEnabled: true}
+	saramaConf := sarama.NewConfig()
+
+	err := configureTLS(&conf, saramaConf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if saramaConf.Net.TLS.Config == nil {
+		t.Fatal("expected non-nil TLS config")
+	}
+	if saramaConf.Net.TLS.Config.RootCAs != nil {
+		t.Error("expected nil RootCAs (system CA trust store)")
+	}
+	if len(saramaConf.Net.TLS.Config.Certificates) != 0 {
+		t.Error("expected no client certificates")
+	}
+}
+
+func TestConfigureTLS_PartialCerts_ReturnsError(t *testing.T) {
 	tests := []struct {
 		name string
 		conf Config
 	}{
-		{"missing all", Config{TLSEnabled: true}},
 		{"missing cert and key", Config{TLSEnabled: true, CACerts: "/tmp/ca.pem"}},
 		{"missing ca and key", Config{TLSEnabled: true, TLSCert: "/tmp/cert.pem"}},
 		{"missing ca and cert", Config{TLSEnabled: true, TLSKey: "/tmp/key.pem"}},
@@ -276,9 +294,9 @@ func TestConfigureTLS_EnabledMissingCerts(t *testing.T) {
 			saramaConf := sarama.NewConfig()
 			err := configureTLS(&tt.conf, saramaConf)
 			if err == nil {
-				t.Fatal("expected error when TLS enabled with missing cert fields")
+				t.Fatal("expected error when TLS enabled with partial cert fields")
 			}
-			if !strings.Contains(err.Error(), "TLS enabled but") {
+			if !strings.Contains(err.Error(), "mTLS requires all three") {
 				t.Errorf("unexpected error message: %s", err)
 			}
 		})


### PR DESCRIPTION
## Summary
- When TLS is enabled but no custom certificates are provided, use the system CA trust store instead of returning an error
- This supports AWS MSK `SASL_SSL` connections where brokers use public Amazon Trust Services certificates
- Mutual TLS (mTLS) is still enforced when any cert field is partially set — all three must be provided together

## Test plan
- [x] `TestConfigureTLS_EnabledNoCerts_UsesSystemCA` — TLS enabled without certs uses system trust store
- [x] `TestConfigureTLS_PartialCerts_ReturnsError` — partial cert config still returns error
- [x] `TestConfigureTLS_DisabledDoesNothing` — existing test still passes
- [x] All existing tests pass